### PR TITLE
Upgrade to node js version 16

### DIFF
--- a/.github/workflows/typescript-angular-build.yml
+++ b/.github/workflows/typescript-angular-build.yml
@@ -11,7 +11,7 @@ jobs:
             pricemonitor-internal-typescript-angular,
             pricemonitor-internal-typescript-angular-13,
           ]
-        node-version: [12.x]
+        node-version: [16.x]
     defaults:
       run:
         working-directory: clients/${{ matrix.angular_client_dir }}/

--- a/.github/workflows/typescript-angular-cd.yaml
+++ b/.github/workflows/typescript-angular-cd.yaml
@@ -13,7 +13,7 @@ jobs:
             pricemonitor-internal-typescript-angular,
             pricemonitor-internal-typescript-angular-13,
           ]
-        node-version: [12.x]
+        node-version: [16.x]
     defaults:
       run:
         working-directory: clients/${{ matrix.angular_client_dir }}/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ tmp/
 target/
 .bsp/
 .idea/
-
+*.iml


### PR DESCRIPTION
Github recommends to use version 16 as opposed to 12 [1]. Failing action can be found here [2].
Little investigation [3] shows that it's sufficient to upgrade version number only. Although this [3] uses checkout version 3, but I don't want to upgrade it directly and would like to see if things work by only upgrading version

[1] https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ 
[2] https://github.com/Patagona/pricemonitor-clients/actions/runs/4115492560 
[3] https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs