### PR TITLE
Minor updates action versions to work with Node.js 16

### DIFF
--- a/.github/workflows/scala-shttp-cd.yaml
+++ b/.github/workflows/scala-shttp-cd.yaml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Setup Scala
-      uses: olafurpg/setup-scala@v10
+      uses: olafurpg/setup-scala@v11
       with:
         java-version: "adopt@1.8"
     - name: Coursier cache
-      uses: coursier/cache-action@v5
+      uses: coursier/cache-action@v6
     - name: Build
       run: |
         sbt -v -Dfile.encoding=UTF-8 +publish

--- a/.github/workflows/scala-sttp-build.yaml
+++ b/.github/workflows/scala-sttp-build.yaml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Setup Scala
-      uses: olafurpg/setup-scala@v10
+      uses: olafurpg/setup-scala@v11
       with:
         java-version: "adopt@1.8"
     - name: Coursier cache
-      uses: coursier/cache-action@v5
+      uses: coursier/cache-action@v6
     - name: Build
       run: |
         sbt -v -Dfile.encoding=UTF-8 +compile

--- a/.github/workflows/typescript-angular-build.yml
+++ b/.github/workflows/typescript-angular-build.yml
@@ -17,7 +17,7 @@ jobs:
         working-directory: clients/${{ matrix.angular_client_dir }}/
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/typescript-angular-cd.yaml
+++ b/.github/workflows/typescript-angular-cd.yaml
@@ -19,7 +19,7 @@ jobs:
         working-directory: clients/${{ matrix.angular_client_dir }}/
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/