### PR TITLE
CON-406 using v1.6.1 for configure-aws-credentials

### DIFF
--- a/.github/workflows/scala-shttp-cd.yaml
+++ b/.github/workflows/scala-shttp-cd.yaml
@@ -28,7 +28,7 @@ jobs:
     # https://www.automat-it.com/post/using-github-actions-with-aws-iam-roles
     # https://github.com/aws-actions/configure-aws-credentials/blob/master/action.yml
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v2.2.0
+      uses: aws-actions/configure-aws-credentials@v1.6.1
       with:
         # Role used here: pat-pricemonitorclients-p-iam-githubactions-1a3v
         role-to-assume: ${{secrets.AWS_ROLE_TO_ASSUME}}


### PR DESCRIPTION
I saw the following warnings with latest version, hence I reverted these changes
```
(node:1589) NOTE: We are formalizing our plans to enter AWS SDK for JavaScript (v2) into maintenance mode in 2023.

Please migrate your code to use AWS SDK for JavaScript (v3).
```