### PR TITLE
Downgrades an OAS 3.1 document to still allow proxy generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 .bsp/
 .idea/
 *.iml
+openapi-internal-fixedup.yaml

--- a/openapi-internal.yaml
+++ b/openapi-internal.yaml
@@ -1,211 +1,261 @@
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   contact:
-    name: Patagona GmbH
-    url: https://patagona.de/
-  title: Pricemonitor API
-  version: 0.0.6771
+    name: Omnia Retail
+    url: https://www.omniaretail.com/
+  title: Pricemonitor API of Omnia Retail
+  summary: The API powering the UI of Omnia 2.0 which can also be used directly by customers.
+  description: |
+    This is a RESTful API that provides access to the backend of Omnia 2.0. It is used to manage products, offers, contracts and more.
+  version: TEST
+  x-logo:
+    url: 'https://www.omniaretail.com/hubfs/Omnia%20Logo%20SVG/Omnia_Retail_Full_Colour_Logo_On_White_RGB.svg'
+    altText: Omnia Retail
 servers:
-- description: Production server
-  url: https://api.patagona.de
+  - url: https://api.patagona.de
+    description: Production API
 security:
-- BasicAuth: []
-- BearerAuth: []
+  - BasicAuth: []
+  - BearerAuth: []
 tags:
-- description: Manage your account
-  name: account
-- description: Company management related endpoints
-  name: companies
-- description: Manage your data-feeds
-  name: feeds
-- description: Manage your orders
-  name: orders
-- description: View price recommendations
-  name: pricerecommendations
-- description: Manage your products
-  name: products
-- description: Manage your contract
-  name: settings
-- description: See all of your tasks
-  name: tasks
+  - name: overview
+    x-displayName: Overview
+    x-traitTag: true
+    description: |-
+      Overview, explanation and pointers to the API documentation.
+
+      ## Introduction
+
+      The Omnia 2.0 API (formerly known as the Pricemonitor API) gives access to the superpowers behind the Omnia Retail platform.
+
+      The [UI of Omnia 2.0](https://app.omniaretail.com/) is the main consumer of the API, but we also have endpoints available to customers to integrate the API directly with their own systems.
+
+      ## Common use cases
+
+      - Provide offers for custom sources via API
+      - Manage your product assortment via API
+      - Retrieve price reommendations from Omnia 2.0 via API
+  - name: products
+    x-displayName: Products Management
+    description: Operations to manage your products.
+  - name: pricerecommendations
+    x-displayName: Price Recommendations
+    description: Operations to get price recommendations calculated by the platform.
+  - name: offers
+    x-displayName: Offers
+    description: Operations to get and manage offers.
+  - name: feeds
+    x-displayName: Feeds Management
+    description: Manage your data-feeds.
+  - name: account
+    x-displayName: Users Management
+    x-audience: Internal
+    description: |-
+      Operations to manage user accounts.
+      This includes sign up, log in, and log out. Primarily used for user management.
+      > Note: these operations should not be directly used by customers, but by the platform itself or by customers through the UI.
+  - name: logs
+    x-displayName: Logs Management
+    description: |-
+      Operations to store log messages in the platform.
+      One could integrate this API in his/her own system and publish the integration logs to the platform so that Omnia Retail could analyze them.
+  - name: companies
+    x-displayName: Company Management
+    description: Company management related endpoints.
+  - name: orders
+    x-displayName: Orders Management
+    description: Manage your orders.
+  - name: settings
+    x-displayName: Settings Management
+    description: Operations to manage the settings of contracts. Very few are available to customers directly.
+  - name: tasks
+    x-displayName: Tasks Management
+    description: Operations to view and manage the tasks running in the platform. Customers can only view tasks.
+  - name: strategy
+    x-displayName: Strategies Management
+    description: Operations to view and manage the pricing strategies.
+  - name: scenariostrategy
+    x-displayName: Scenario Strategies Management
+    x-audience: Internal
+    description: Operations to manage the scenario strategies.
+  - name: domains
+    x-displayName: Domains
+    description: Operations to view all supported domains.
+  - name: controlpanel
+    x-displayName: Control Panel
+    x-audience: Internal
+    description: Operations used by the control panel.
+  - name: pluginregistration
+    x-displayName: Plugin Registration
+    description: Operations to view registered plugins.
+  - name: looker
+    x-displayName: Looker
+    x-audience: Internal
+    description: Operations to manage Looker dashboards.
+  - name: amazon-integration
+    x-displayName: Amazon Integration
+    x-audience: Internal
+    description: Operations to manage the Amazon integration.
+  - name: monitoring-schedules
+    x-displayName: Monitoring Schedules
+    x-audience: Internal
+    description: Operations to manage the monitoring schedules.
+  - name: preprocessing
+    x-displayName: Pre-processing
+    x-audience: Internal
+    description: Operations to manage the pre-processing.
+  - name: vendor-shop-mapping
+    x-displayName: Vendor Shop Mapping
+    x-audience: Internal
+    description: Operations to manage the vendor shop mappings.
+  - name: deprecated
+    x-displayName: Deprecated
+    description: All operations that are deprecated and should not be used anymore. Also not internally.
+  - name: internal
+    x-displayName: Internal Only
+    x-audience: Internal
+    description: |-
+      All operations not intended for direct consumption by customers.
+      > Note: not directly used by customers, but by the platform itself.
+  - name: undocumented
+    x-displayName: Undocumented
+    x-audience: Internal
+    description: |-
+      All operations that are not yet documented.  
+      > Note: all operations intended for public usage should be documented.
 paths:
   /api/v3/vendor/contracts/{contractId}/settings/repricingstrategy/history:
     get:
       deprecated: true
-      operationId: getStrategyHistory
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - $ref: '#/components/parameters/contractIdParam'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetPricingStrategyHistoryApiResponse'
           description: List of metadata of all strategy versions
       summary: Get a list of metadata of all strategy versions for a contract
+      operationId: getStrategyHistory
       tags:
-      - strategy
+        - strategy
   /api/v3/vendor/contracts/{contractId}/settings/pricingstrategies/history:
     get:
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - $ref: '#/components/parameters/contractIdParam'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetPricingStrategyHistoryApiResponse'
           description: List of metadata of all strategy versions
       summary: Get a list of metadata of all strategy versions for a contract
+      operationId: getPricingStrategyHistory
       tags:
-      - strategy
+        - strategy
   /api/v3/vendor/contracts/{contractId}/settings/pricingstrategies/scenarios:
+    x-audience: Internal
     get:
-      operationId: getAllScenariosMetadata
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - $ref: '#/components/parameters/contractIdParam'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 items:
                   $ref: '#/components/schemas/ScenarioStrategyMetadataResponseApiResponse'
-                type: array
           description: List of all strategy scenarios metadata
       summary: Get a list of all strategy scenarios metadata for a contract
+      operationId: getAllScenariosMetadata
       tags:
-      - scenariostrategy
-      - internal
+        - scenariostrategy
+        - internal
     post:
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - $ref: '#/components/parameters/contractIdParam'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostScenarioStrategyResponseApiResponse'
+          description: A new scenario strategy was added
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Strategy must be valid and consistent with the schema version. Required fields need to be filled.
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PostScenarioStrategyRequest'
         description: The scenario strategy to be stored. Including the necessary metadata.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostScenarioStrategyResponseApiResponse'
-          description: A new scenario strategy was added
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: Strategy must be valid and consistent with the schema version.
-            Required fields need to be filled.
+      operationId: addPricingStrategyScenario
       tags:
-      - scenariostrategy
-      - internal
+        - scenariostrategy
+        - internal
   /api/v3/vendor/contracts/{contractId}/settings/pricingstrategies/scenarios/{scenarioId}:
+    x-audience: Internal
     get:
-      operationId: getScenarioById
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: ID of the required strategy scenario
-        explode: false
-        in: path
-        name: scenarioId
-        required: true
-        schema:
-          type: integer
-        style: simple
+        - $ref: '#/components/parameters/contractIdParam'
+        - description: ID of the required strategy scenario
+          in: path
+          name: scenarioId
+          required: true
+          schema:
+            type: integer
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ScenarioStrategyResponse'
           description: A strategy scenario
-        "404":
+        '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
           description: Strategy scenario with the provided Id was not found.
       summary: Get a strategy scenario with the provided scenario Id
+      operationId: getScenarioById
       tags:
-      - scenariostrategy
-      - internal
+        - scenariostrategy
+        - internal
   /api/v3/domains:
     get:
-      description: |
-        This endpoint provides all domains which are supported by our system.
-        Along with other attributes we are providing the corresponding possible offer sources.
-        Only domains which include the offer source DEFAULT_MONITORING are supported out-of-the-box by our monitoring pipeline.
-      operationId: getAllDomainsV3
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetAllDomainsV3ApiResponse'
           description: A list of domains
-      summary: Get a list of all available domains
+      summary: Get a list of all available domains (V3)
+      description: |
+        This endpoint provides all domains which are supported by our system.
+        Along with other attributes we are providing the corresponding possible offer sources.
+        Only domains which include the offer source DEFAULT_MONITORING are supported out-of-the-box by our monitoring pipeline.
+      operationId: getAllDomainsV3
       tags:
-      - domains
+        - domains
   /controlpanel/api/v3/domains:
+    x-audience: Internal
     post:
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostAdminAddDomainBodyV3'
-        description: The domain to be added and its offer sources
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/PostAdminAddDomainV3ApiResponse'
           description: A new domain was added
-        "400":
+        '400':
           content:
             application/json:
               schema:
@@ -215,82 +265,105 @@ paths:
             - Domain must be a valid internet domain and non-empty
             - Domain name must be unique and non-empty
             - Please refer to the request schema for what constitutes valid offer sources and a valid domain
-      summary: Add a new domain
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostAdminAddDomainBodyV3'
+        description: The domain to be added and its offer sources
       tags:
-      - controlpanel
-      - internal
+        - controlpanel
+        - internal
+      summary: Add a new domain
   /version:
+    x-audience: Internal
     get:
-      operationId: version
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/VersionApiResponse'
           description: Current application version.
-      security: []
-      summary: Get the current application version
       tags:
-      - controlpanel
-      - internal
+        - controlpanel
+        - internal
+      operationId: version
+      summary: Get the current application version
+      security: []
   /api/1/{contractId}/products/analysis/pricerecommendations:
     get:
-      operationId: getPriceRecommendations
+      deprecated: true
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Where to start fetching the recommendations
-        example: 0
-        explode: true
-        in: query
-        name: start
-        required: false
-        schema:
-          default: 0
-          format: int32
-          type: integer
-        style: form
-      - description: Maximal number of results
-        example: 100
-        explode: true
-        in: query
-        name: limit
-        required: false
-        schema:
-          default: 10000
-          format: int32
-          type: integer
-        style: form
-      - description: Timestamp of the oldest results
-        example: 2019-01-01T00:00:00.000Z
-        explode: true
-        in: query
-        name: since
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
+        - $ref: '#/components/parameters/contractIdParam'
+        - description: Where to start fetching the recommendations
+          in: query
+          name: start
+          required: false
+          example: 0
+          schema:
+            default: 0
+            format: int32
+            type: integer
+        - description: Maximal number of results
+          in: query
+          name: limit
+          required: false
+          example: 100
+          schema:
+            default: 10000
+            format: int32
+            type: integer
+        - description: Timestamp of the oldest results
+          in: query
+          name: since
+          required: false
+          example: '2019-01-01T00:00:00.000Z'
+          schema:
+            format: date-time
+            type: string
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetPriceRecommendationsResponse'
           description: No response was specified
-      summary: Get price recommendations (deprecated)
       tags:
-      - pricerecommendations
+        - pricerecommendations
+      operationId: getPriceRecommendations
+      summary: Get price recommendations
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/companies:
     post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateCompanyApiResponse'
+          description: No response was specified
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: The company name may not be empty
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: User already belongs to a company
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: The company could not be created
+      tags:
+        - companies
       operationId: createCompany
       requestBody:
         content:
@@ -299,71 +372,39 @@ paths:
               type: string
         description: The company's name
         required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CreateCompanyApiResponse'
-          description: No response was specified
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: The company name may not be empty
-        "403":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: User already belongs to a company
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: The company could not be created
       summary: Allows users without one to create a new Company
-      tags:
-      - companies
   /api/2/companies/{companyId}/contracts:
+    parameters:
+      - $ref: '#/components/parameters/companyIdParam'
     get:
-      operationId: getCompanyContracts
-      parameters:
-      - description: ID of a company
-        example: 1
-        explode: false
-        in: path
-        name: companyId
-        required: true
-        schema:
-          format: int64
-          type: integer
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetCompanyContractsApiResponse'
           description: No response was specified
-      summary: Get all contracts for given company
       tags:
-      - companies
+        - companies
+      operationId: getCompanyContracts
+      summary: Get all contracts for given company
     post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AddCompanyContractApiResponse'
+          description: No response was specified
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Unable to add contract for company ID
+      tags:
+        - companies
       operationId: addCompanyContract
-      parameters:
-      - description: ID of a company
-        example: 1
-        explode: false
-        in: path
-        name: companyId
-        required: true
-        schema:
-          format: int64
-          type: integer
-        style: simple
       requestBody:
         content:
           application/json:
@@ -371,82 +412,36 @@ paths:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CreateContractRequest'
         description: Contract to be added
         required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AddCompanyContractApiResponse'
-          description: No response was specified
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: Unable to add contract for company ID
       summary: Add contract for given company
-      tags:
-      - companies
   /api/2/m/contracts/{contractId}/settings/callbacks:
-    delete:
-      operationId: deleteCallbackSettingsManufacturerV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
+    x-audience: Internal
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
     get:
-      operationId: getCallbacks
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Callbacks'
           description: '-'
-        "404":
+        '404':
           description: Settings for this contract don't exist yet
-      summary: Get callbacks
       tags:
-      - settings
+        - settings
+        - internal
+      operationId: getCallbacks
+      summary: Get callbacks
     put:
+      responses:
+        '200':
+          description: '-'
+        '404':
+          description: Settings for this contract don't exist yet
+      tags:
+        - settings
+        - internal
       operationId: putCallbacks
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
@@ -454,31 +449,26 @@ paths:
               $ref: '#/components/schemas/Callbacks'
         description: Callbacks
         required: true
-      responses:
-        "200":
-          description: '-'
-        "404":
-          description: Settings for this contract don't exist yet
       summary: Set callbacks
+    delete:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
       tags:
-      - settings
+        - internal
+        - undocumented
+        - settings
+      operationId: deleteCallbackSettingsManufacturerV2
   /api/2/v/contracts/{contractId}/feeds:
     get:
-      description: Feeds can contain offer-related information such as price recommendations.
-        They can be configured to match individual demands.
-      operationId: getFeeds
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - $ref: '#/components/parameters/contractIdParam'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
@@ -487,291 +477,214 @@ paths:
                 type: array
                 uniqueItems: true
           description: No response was specified
-      summary: Get all feeds
       tags:
-      - feeds
+        - feeds
+      description: Feeds can contain offer-related information such as price recommendations. They can be configured to match individual demands.
+      operationId: getFeeds
+      summary: Get all feeds
     post:
+      x-audience: Internal
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - feeds
       operationId: postFeedVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - feeds
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/feeds/{feedId}:
-    delete:
-      operationId: deleteFeedVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
-        name: feedId
-        required: true
-        schema:
-          type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - feeds
     get:
-      description: A feed can contain offer-related information such as price recommendations.
-        Feeds can be configured to match individual demands.
-      operationId: getFeed
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: ID of the feed
-        explode: false
-        in: path
-        name: feedId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - $ref: '#/components/parameters/contractIdParam'
+        - description: ID of the feed
+          in: path
+          name: feedId
+          required: true
+          schema:
+            type: string
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Feed'
           description: No response was specified
-        "404":
+        '404':
           description: Not found
-      summary: Find feed by ID
       tags:
-      - feeds
+        - feeds
+      description: A feed can contain offer-related information such as price recommendations. Feeds can be configured to match individual demands.
+      operationId: getFeed
+      summary: Find feed by ID
     put:
-      operationId: putFeedVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
-        name: feedId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: This is a generated entry and needs to be described.
+      x-audience: Internal
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - feeds
+        - internal
+        - undocumented
+        - feeds
+      operationId: putFeedVendorV2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
+    delete:
+      x-audience: Internal
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - feeds
+      operationId: deleteFeedVendorV2
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
+        name: feedId
+        required: true
+        schema:
+          type: string
   /api/2/v/contracts/{contractId}/feeds/{feedId}/export/delta:
     delete:
-      description: Dismiss already fetched feed-entries, so they will not be part
-        of future responses.
-      operationId: excludeFetchedFeedData
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: ID of the feed
-        explode: false
-        in: path
-        name: feedId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - $ref: '#/components/parameters/contractIdParam'
+        - description: ID of the feed
+          in: path
+          name: feedId
+          required: true
+          schema:
+            type: string
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Feed'
           description: No response was specified
-        "404":
+        '404':
           description: Not found
-      summary: Dismiss already fetched feed-entries
       tags:
-      - feeds
+        - feeds
+      description: Dismiss already fetched feed-entries, so they will not be part of future responses.
+      operationId: excludeFetchedFeedData
+      summary: Dismiss already fetched feed-entries
     get:
+      x-audience: Internal
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - feeds
       operationId: getFeedExportDeltaVendorV2
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
+        - in: query
+          name: fileName
+          required: false
+          schema:
+            type: string
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
         name: feedId
         required: true
         schema:
           type: string
-        style: simple
-      - explode: true
-        in: query
+  /api/2/v/contracts/{contractId}/feeds/{feedId}/export/delta/{fileName}:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/contractIdParam'
+        - description: ID of the feed
+          in: path
+          name: feedId
+          required: true
+          schema:
+            type: string
+        - description: fileName
+          in: path
+          name: fileName
+          required: true
+          schema:
+            default: my-feed.csv
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Feed'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/Feed'
+          description: No response was specified
+        '404':
+          description: Not found
+      tags:
+        - feeds
+      description: In contrast of normal feeds, feed-deltas return only results, that are new since the last (DELETE-)request.
+      operationId: getFeedExportDelta
+      summary: Retrieve all feed-entries after last request
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
+        name: feedId
+        required: true
+        schema:
+          type: string
+      - in: path
         name: fileName
         required: false
         schema:
           type: string
-        style: form
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - feeds
-  /api/2/v/contracts/{contractId}/feeds/{feedId}/export/delta/{fileName}:
-    get:
-      description: In contrast of normal feeds, feed-deltas return only results, that
-        are new since the last (DELETE-)request.
-      operationId: getFeedExportDelta
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: ID of the feed
-        explode: false
-        in: path
-        name: feedId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: fileName
-        explode: false
-        in: path
-        name: fileName
-        required: true
-        schema:
-          default: my-feed.csv
-          type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Feed'
-            text/csv:
-              schema:
-                $ref: '#/components/schemas/Feed'
-          description: No response was specified
-        "404":
-          description: Not found
-      summary: Retrieve all feed-entries after last request
-      tags:
-      - feeds
   /api/2/v/contracts/{contractId}/feeds/{feedId}/export/{fileName}:
     get:
-      description: Lets you download a file, containing all the data of the feed.
-      operationId: getFeedExport
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: ID of the feed
-        explode: false
-        in: path
-        name: feedId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: fileName
-        explode: false
-        in: path
-        name: fileName
-        required: true
-        schema:
-          default: my-feed.csv
-          type: string
-        style: simple
+        - $ref: '#/components/parameters/contractIdParam'
+        - description: ID of the feed
+          in: path
+          name: feedId
+          required: true
+          schema:
+            type: string
+        - description: fileName
+          in: path
+          name: fileName
+          required: true
+          schema:
+            default: my-feed.csv
+            type: string
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
@@ -780,24 +693,45 @@ paths:
               schema:
                 $ref: '#/components/schemas/Feed'
           description: No response was specified
-        "404":
+        '404':
           description: Not found
-      summary: Export feed-data
       tags:
-      - feeds
-  /api/2/v/contracts/{contractId}/orders:
-    post:
-      operationId: postOrders
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
+        - feeds
+      description: Lets you download a file, containing all the data of the feed.
+      operationId: getFeedExport
+      summary: Export feed-data
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
+        name: feedId
         required: true
         schema:
           type: string
-        style: simple
+      - in: path
+        name: fileName
+        required: false
+        schema:
+          type: string
+  /api/2/v/contracts/{contractId}/orders:
+    post:
+      parameters:
+        - $ref: '#/components/parameters/contractIdParam'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostOrdersBulkApiResponse'
+          description: Successfully added orders
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostOrdersBulkApiResponse'
+          description: Unable to add orders
+      tags:
+        - orders
+      operationId: postOrders
       requestBody:
         content:
           application/json:
@@ -805,54 +739,30 @@ paths:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostCustomerOrdersRequestV2'
         description: Orders to be added
         required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostOrdersBulkApiResponse'
-          description: Successfully added orders
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostOrdersBulkApiResponse'
-          description: Unable to add orders
       summary: Add orders in bulk
-      tags:
-      - orders
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/products:
     get:
-      operationId: getProducts
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: "null"
-        explode: true
-        in: query
-        name: attributes
-        required: true
-        schema:
-          enum:
-          - gtin
-          - identifier
-          - name
-          - referencePrice
-          - minPriceBoundary
-          - maxPriceBoundary
-          - tags
-          - strategy
-          type: string
-        style: form
+        - $ref: '#/components/parameters/contractIdParam'
+        - in: query
+          description: Query string to filter products
+          name: attributes
+          required: true
+          schema:
+            type: string
+            enum:
+              - gtin
+              - identifier
+              - name
+              - referencePrice
+              - minPriceBoundary
+              - maxPriceBoundary
+              - tags
+              - strategy
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
@@ -861,40 +771,47 @@ paths:
                 type: array
                 uniqueItems: true
           description: No response was specified
-      summary: Get all products
       tags:
-      - products
+        - products
+      operationId: getProducts
+      summary: Get all products
     put:
-      operationId: putProductsVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: This is a generated entry and needs to be described.
+      x-audience: Internal
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - products
+        - internal
+        - undocumented
+        - products
+      operationId: putProductsVendorV2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/products/csv:
     put:
+      parameters:
+        - $ref: '#/components/parameters/contractIdParam'
+      responses:
+        '200':
+          description: '-'
+        '202':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskIdAndUrl'
+          description: Accepted
+      tags:
+        - products
       description: |-
         Warning: Deletes all existing products.
                 <br/>Note that this will not happen immediately. Instead, you receive the ID of a task that has been created.
@@ -912,16 +829,6 @@ paths:
                 </ul>
                 <br/>Column separator must be semicolon, the decimal separator must be dot. File encoding must be UTF-8.
       operationId: putCSVProducts
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           text/csv:
@@ -929,162 +836,112 @@ paths:
               type: string
         description: CSV file containing the products
         required: true
-      responses:
-        "200":
-          description: '-'
-        "202":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TaskIdAndUrl'
-          description: Accepted
       summary: Set products via CSV file
-      tags:
-      - products
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/result/offers:
     get:
-      operationId: getOffers
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Start product index for pagination
-        explode: true
-        in: query
-        name: start
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
-      - description: Number of products for pagination
-        explode: true
-        in: query
-        name: limit
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
-      - description: Timestamp of start of time range, formatted as ISO Date (i.e.
-          2018-04-06T13:46:13Z) in UTC. If this value is omitted and {endDate} is
-          given, {startDate} is set to {endDate} - 48 hours. If both values are omitted,
-          the range is 'NOW - 48 hours to NOW'.
-        explode: true
-        in: query
-        name: startDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - description: Timestamp of end of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z)
-          in UTC. If this value is omitted and {startDate} is given, {endDate} is
-          set to {startDate} + 48 hours. If both values are omitted, the range is
-          'NOW - 48 hours to NOW'.
-        explode: true
-        in: query
-        name: endDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
+        - $ref: '#/components/parameters/contractIdParam'
+        - description: Start product index for pagination
+          in: query
+          name: start
+          required: true
+          schema:
+            format: int32
+            type: integer
+        - description: Number of products for pagination
+          in: query
+          name: limit
+          required: true
+          schema:
+            format: int32
+            type: integer
+        - $ref: '#/components/parameters/startDate'
+        - $ref: '#/components/parameters/endDate'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetOffersResponse'
           description: No response was specified
-      summary: Get all offers for all products
       tags:
-      - products
+        - products
+      operationId: getOffers
+      summary: Get all offers for all products
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/result/pricerecommendations:
     get:
-      operationId: getPriceRecommendation
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Timestamp of start of time range, formatted as ISO Date (i.e.
-          2018-04-06T13:46:13Z) in UTC
-        explode: true
-        in: query
-        name: startTime
-        required: true
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - description: Timestamp of end of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z)
-          in UTC
-        explode: true
-        in: query
-        name: endTime
-        required: true
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - description: Start price-recommendation index for pagination
-        explode: true
-        in: query
-        name: start
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
-      - description: Number of price-recommendations for pagination
-        explode: true
-        in: query
-        name: limit
-        required: false
-        schema:
-          default: 100
-          format: int32
-          type: integer
-        style: form
+        - $ref: '#/components/parameters/contractIdParam'
+        - description: Timestamp of start of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z) in UTC
+          in: query
+          name: startTime
+          required: true
+          schema:
+            format: date-time
+            type: string
+        - description: Timestamp of end of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z) in UTC
+          in: query
+          name: endTime
+          required: true
+          schema:
+            format: date-time
+            type: string
+        - description: Start price-recommendation index for pagination
+          in: query
+          name: start
+          required: true
+          schema:
+            format: int32
+            type: integer
+        - description: Number of price-recommendations for pagination
+          in: query
+          name: limit
+          required: false
+          schema:
+            default: 100
+            format: int32
+            type: integer
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetPriceRecommendationApiResponse'
-          description: A paginated list of price recommendations is returned for the
-            specified timerange. Only the newest price recommendations are returned
-            in case of multiple price recommendations per product.
-      summary: Get all price recommendations
+          description: A paginated list of price recommendations is returned for the specified timerange. Only the newest price recommendations are returned in case of multiple price recommendations per product.
       tags:
-      - pricerecommendations
+        - pricerecommendations
+      operationId: getPriceRecommendation
+      summary: Get all price recommendations
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/settings/domains:
-    get:
-      operationId: getDomainsVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+    put:
       responses:
-        "200":
+        '200':
+          description: The domains setting for this contract was saved.
+        '404':
+          description: Settings for this contract do not exist yet
+      tags:
+        - settings
+      operationId: putDomains
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              type: array
+        description: Settings
+        required: true
+      summary: Set contract domains
+    get:
+      x-audience: Internal
+      responses:
+        '200':
           content:
             application/json:
               schema:
@@ -1095,116 +952,61 @@ paths:
                     type: array
           description: A list of configured domains is returned.
       tags:
-      - internal
-      - settings
-    put:
-      operationId: putDomains
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              items:
-                type: string
-              type: array
-        description: Settings
-        required: true
-      responses:
-        "200":
-          description: The domains setting for this contract was saved.
-        "404":
-          description: Settings for this contract do not exist yet
-      summary: Set contract domains
-      tags:
-      - settings
+        - internal
+        - settings
+      operationId: getDomainsVendorV2
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/tasks:
     get:
-      description: The search can be narrowed down by providing the IDs of the tasks,
-        separated by comma
-      operationId: getTasksVendorV2
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Ids of the tasks
-        explode: true
-        in: query
-        name: taskIdsFilter
-        required: false
-        schema:
-          type: string
-        style: form
-      - description: Desired task type
-        explode: true
-        in: query
-        name: taskTypeFilter
-        required: false
-        schema:
-          type: string
-        style: form
-      - description: Maximal number of results
-        example: 10
-        explode: true
-        in: query
-        name: limit
-        required: false
-        schema:
-          default: 100
-          format: int32
-          type: integer
-        style: form
-      - description: Flag whether to include failures in the response
-        explode: true
-        in: query
-        name: includeFailures
-        required: false
-        schema:
-          default: true
-          type: boolean
-        style: form
-      - description: Comma separated task state filter
-        explode: true
-        in: query
-        name: taskState
-        required: false
-        schema:
-          type: string
-        style: form
-      - description: Oldest returned creation date in UTC
-        explode: true
-        in: query
-        name: minCreationDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - description: Newest returned creation date in UTC
-        explode: true
-        in: query
-        name: maxCreationDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
+        - $ref: '#/components/parameters/contractIdParam'
+        - description: Ids of the tasks
+          in: query
+          name: taskIdsFilter
+          required: false
+          schema:
+            type: string
+        - description: Desired task type
+          in: query
+          name: taskTypeFilter
+          required: false
+          schema:
+            type: string
+        - description: Maximal number of results
+          in: query
+          name: limit
+          required: false
+          example: 10
+          schema:
+            default: 100
+            format: int32
+            type: integer
+        - description: Flag whether to include failures in the response
+          in: query
+          name: includeFailures
+          schema:
+            type: boolean
+            default: true
+        - description: Comma separated task state filter
+          in: query
+          name: taskState
+          schema:
+            type: string
+        - description: Oldest returned creation date in UTC
+          in: query
+          name: minCreationDate
+          schema:
+            type: string
+            format: date-time
+        - description: Newest returned creation date in UTC
+          in: query
+          name: maxCreationDate
+          schema:
+            type: string
+            format: date-time
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
@@ -1213,183 +1015,179 @@ paths:
                 type: array
                 uniqueItems: true
           description: No response was specified
-      summary: Find all tasks
       tags:
-      - tasks
+        - tasks
+      description: The search can be narrowed down by providing the IDs of the tasks, separated by comma
+      operationId: getTasksVendorV2
+      summary: Find all tasks
     post:
-      operationId: createTaskVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CreateTaskBodyV2'
-        description: Create a new task
+      x-audience: Internal
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: Task has been created successfully
       tags:
-      - internal
-      - undocumented
-      - tasks
+        - internal
+        - undocumented
+        - tasks
+      operationId: createTaskVendorV2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CreateTaskBodyV2'
+        description: Create a new task
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/tasks/{taskId}:
     get:
-      description: Returns a task, associated with a certain contract and identified
-        by its ID
-      operationId: getTaskVendorV2
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Id of the task
-        explode: false
-        in: path
-        name: taskId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - $ref: '#/components/parameters/contractIdParam'
+        - description: Id of the task
+          in: path
+          name: taskId
+          required: true
+          schema:
+            type: string
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TaskWithContractResourceApiResponse'
           description: No response was specified
-        "404":
+        '404':
           description: Not found
-      summary: Find task by ID
       tags:
-      - tasks
+        - tasks
+      description: Returns a task, associated with a certain contract and identified by its ID
+      operationId: getTaskVendorV2
+      summary: Find task by ID
     put:
-      operationId: updateTaskVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
-        name: taskId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: This is a generated entry and needs to be described.
+      x-audience: Internal
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - tasks
+        - internal
+        - undocumented
+        - tasks
+      operationId: updateTaskVendorV2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
+        name: taskId
+        required: true
+        schema:
+          type: string
   /api/account:
+    x-audience: Internal
     get:
-      description: Returns the current user with its companies and contracts
-      operationId: userInfo
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.UserInfo'
           description: No response was specified
-      summary: Details of the current user
       tags:
-      - account
+        - account
+        - internal
+      description: Returns the current user with its companies and contracts
+      operationId: userInfo
+      summary: Details of the current user
     post:
+      responses:
+        '200':
+          description: No response was specified
+        '201':
+          description: User was created and confirmation e-mail was sent
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Unable to create the user because of bad request data
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Unable to create the user because of an unexpected error
+      tags:
+        - account
+        - internal
       operationId: userSignup
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UserSignupRequest'
-        description: The user signup data
+        description: The user sign up data
         required: true
-      responses:
-        "200":
-          description: No response was specified
-        "201":
-          description: User was created and confirmation eMail was sent
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: Unable to create the user because of bad request data
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: Unable to create the user because of an unexpected error
-      summary: Create a new user account in the Pricemonitor
-      tags:
-      - account
+      summary: Create a new user account in the system
   /api/account/confirm/{token}:
+    x-audience: Internal
     head:
-      operationId: checkUserConfirmation
       parameters:
-      - explode: false
-        in: path
-        name: token
-        required: true
-        schema:
-          type: string
-        style: simple
+        - in: path
+          name: token
+          required: true
+          schema:
+            type: string
       responses:
-        "200":
+        '200':
           description: No response was specified
-        "204":
+        '204':
           description: Confirmation token was found
-        "404":
+        '404':
           description: No such confirmation token was found
-      summary: Check if a specific confirmation token exists
       tags:
-      - account
+        - account
+        - internal
+      operationId: checkUserConfirmation
+      summary: Check if a specific confirmation token exists
     post:
-      operationId: confirmUser
       parameters:
-      - explode: false
-        in: path
-        name: token
-        required: true
-        schema:
-          type: string
-        style: simple
+        - in: path
+          name: token
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: No response was specified
+        '204':
+          description: User was confirmed & logged in
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Unable to confirm the user because of bad request data
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Unable to confirm the user because of an unexpected error
+      tags:
+        - account
+        - internal
+      operationId: confirmUser
       requestBody:
         content:
           application/json:
@@ -1397,253 +1195,144 @@ paths:
               type: string
         description: The password that should be set on the confirmed user
         required: true
-      responses:
-        "200":
-          description: No response was specified
-        "204":
-          description: User was confirmed & logged in
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: Unable to confirm the user because of bad request data
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: Unable to confirm the user because of an unexpected error
       summary: Confirm an unconfirmed user
-      tags:
-      - account
-  /api/v3/manufacturer/contracts/{contractId}/offers:
-    get:
-      description: Returns the newest offers for a given time range.
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
+    parameters:
+      - in: path
+        name: token
         required: true
         schema:
           type: string
-        style: simple
-      - description: Where to start fetching the products
-        explode: true
-        in: query
-        name: start
-        required: false
-        schema:
-          default: 0
-          format: int32
-          type: integer
-        style: form
-      - description: Maximum number of results
-        example: 1000
-        explode: true
-        in: query
-        name: limit
-        required: false
-        schema:
-          default: 1000
-          format: int32
-          type: integer
-        style: form
-      - description: Whether to return tags of products or not.
-        explode: true
-        in: query
-        name: includeTags
-        required: false
-        schema:
-          default: true
-          type: boolean
-        style: form
-      - description: Timestamp of start of time range, formatted as ISO Date (i.e.
-          2018-04-06T13:46:13Z) in UTC. If this value is omitted and {endDate} is
-          given, {startDate} is set to {endDate} - 48 hours. If both values are omitted,
-          the range is 'NOW - 48 hours to NOW'.
-        explode: true
-        in: query
-        name: startDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - description: Timestamp of end of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z)
-          in UTC. If this value is omitted and {startDate} is given, {endDate} is
-          set to {startDate} + 48 hours. If both values are omitted, the range is
-          'NOW - 48 hours to NOW'.
-        explode: true
-        in: query
-        name: endDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
+  /api/v3/manufacturer/contracts/{contractId}/offers:
+    get:
+      summary: Get offers for timerange
+      description: Returns the newest offers for a given time range.
+      parameters:
+        - $ref: '#/components/parameters/contractIdParam'
+        - description: Where to start fetching the products
+          in: query
+          name: start
+          required: false
+          schema:
+            default: 0
+            format: int32
+            type: integer
+        - description: Maximum number of results
+          in: query
+          name: limit
+          required: false
+          example: 1000
+          schema:
+            default: 1000
+            format: int32
+            type: integer
+        - description: Whether to return tags of products or not.
+          in: query
+          name: includeTags
+          required: false
+          schema:
+            default: true
+            type: boolean
+        - $ref: '#/components/parameters/startDate'
+        - $ref: '#/components/parameters/endDate'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetOffersApiResponse'
           description: A list of products with their corresponding offers.
-        "400":
+        '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiError'
-          description: Returned in case of invalid time range or a limit greater than
-            10000.
+          description: Returned in case of invalid time range or a limit greater than 10000.
       tags:
-      - offers
+        - offers
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/v3/manufacturer/contracts/{contractId}/offers/shops:
+    x-audience: Internal
     get:
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Timestamp of start of time range, formatted as ISO Date (i.e.
-          2018-04-06T13:46:13Z) in UTC. If this value is omitted and {endDate} is
-          given, {startDate} is set to {endDate} - 48 hours. If both values are omitted,
-          the range is 'NOW - 48 hours to NOW'. The time range may not exceed 1 week.
-        explode: true
-        in: query
-        name: startDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - description: Timestamp of end of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z)
-          in UTC. If this value is omitted and {startDate} is given, {endDate} is
-          set to {startDate} + 48 hours. If both values are omitted, the range is
-          'NOW - 48 hours to NOW'. The time range may not exceed 1 week.
-        explode: true
-        in: query
-        name: endDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
+        - $ref: '#/components/parameters/contractIdParam'
+        - $ref: '#/components/parameters/startDateOneWeekMax'
+        - $ref: '#/components/parameters/endDateOneWeekMax'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetShopsByDomainResponseV3ApiResponse'
-          description: Shops which have at least one offer for a given time range
-            per domain.
-        "400":
+          description: Shops which have at least one offer for a given time range per domain.
+        '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiError'
           description: Specified time range is invalid (> 7 days).
-      summary: Returns all shops which have at least one offer for a given time range
-        per domain.
       tags:
-      - offers
-      - internal
+        - offers
+        - internal
+      summary: Get shops with offers for time range
+      description: Returns all shops which have at least one offer for a given time range per domain.
   /api/v3/manufacturer/contracts/{contractId}/offers/shop/query:
+    x-audience: Internal
     post:
-      description: Get all offers of a shop. Please note that it might return offers
-        for inactive products.
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - $ref: '#/components/parameters/contractIdParam'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryOffersOfShopV3ApiResponse'
+          description: Returns offers of the shop
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.QueryOffersOfShopRequestV3'
         required: true
+      tags:
+        - products
+        - internal
+      description: Get all offers of a shop. Please note that it might return offers for inactive products.
+  /api/v3/manufacturer/contracts/{contractId}/offers/stats/query:
+    x-audience: Internal
+    post:
+      parameters:
+        - $ref: '#/components/parameters/contractIdParam'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/QueryOffersOfShopV3ApiResponse'
-          description: Returns offers of the shop
+                $ref: '#/components/schemas/PostOfferStatisticsApiResponse'
+          description: Returns a list of offer statistics per product.
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+          description: Returned in case of unparsable request body JSON or unsupported filter.
       tags:
-      - products
-      - internal
-  /api/v3/manufacturer/contracts/{contractId}/offers/stats/query:
-    post:
-      description: 'This operation is used to get offer statistics (e.g. offer count,
-        average price) grouped by product and domain. Warning: This endpoint contains
-        complex query structure and will be replaced in the future. Please note that
-        offer statistics can only be computed for at maximum 2500 products at a time.'
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - products
+        - internal
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PostOfferStatisticsRequest'
         required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostOfferStatisticsApiResponse'
-          description: Returns a list of offer statistics per product.
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-          description: Returned in case of unparsable request body JSON or unsupported
-            filter.
-      tags:
-      - products
-      - internal
+      description: 'This operation is used to get offer statistics (e.g. offer count, average price) grouped by product and domain. Warning: This endpoint contains complex query structure and will be replaced in the future. Please note that offer statistics can only be computed for at maximum 2500 products at a time.'
     summary: Get offer statistics per product
   /api/v3.1/manufacturer/contracts/{contractId}/offers/stats/query:
     post:
-      description: This endpoint can be used to query offer statistics (e.g. offer
-        count, average price) grouped by product. Only the most recent market data
-        is considered per product and domain.
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        $ref: '#/components/requestBodies/PostOfferStatisticsRequestV31Enriched'
+        - $ref: '#/components/parameters/contractIdParam'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
@@ -1651,7 +1340,7 @@ paths:
           description: |
             Returns a list of offer statistics per product.
             When a product has no market data then no offer statistics are returned for that product.
-        "400":
+        '400':
           content:
             application/json:
               schema:
@@ -1662,104 +1351,130 @@ paths:
             - An unsupported filter is provided.
             - The specified time range exceeds 48 hours.
             - The pagination limit exceeds 10,000.
-      summary: Query offer statistics per product.
       tags:
-      - offers
+        - offers
+      requestBody:
+        $ref: '#/components/requestBodies/PostOfferStatisticsRequestV31Enriched'
+      description: This endpoint can be used to query offer statistics (e.g. offer count, average price) grouped by product. Only the most recent market data is considered per product and domain.
+      summary: Query offer statistics per product
   /api/v3/manufacturer/contracts/{contractId}/offers/stats:
+    x-audience: Internal
     get:
       operationId: getOfferStatisticsManufacturerV3
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Timestamp of start of time range, formatted as ISO Date (i.e.
-          2018-04-06T13:46:13Z) in UTC. If this value is omitted and {endDate} is
-          given, {startDate} is set to {endDate} - 48 hours. If both values are omitted,
-          the range is 'NOW - 48 hours to NOW'.
-        explode: true
-        in: query
-        name: startDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - description: Timestamp of end of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z)
-          in UTC. If this value is omitted and {startDate} is given, {endDate} is
-          set to {startDate} + 48 hours. If both values are omitted, the range is
-          'NOW - 48 hours to NOW'.
-        explode: true
-        in: query
-        name: endDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: includeDeliveryCosts
-        required: true
-        schema:
-          type: boolean
-        style: form
+        - $ref: '#/components/parameters/contractIdParam'
+        - $ref: '#/components/parameters/startDate'
+        - $ref: '#/components/parameters/endDate'
+        - in: query
+          name: includeDeliveryCosts
+          required: true
+          schema:
+            type: boolean
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetOfferStatisticsV3ApiResponse'
           description: Returns a list of offer statistics per product.
-        "400":
+        '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiError'
           description: Specified time range is invalid (> 48h).
-      summary: Get offer statistics per product of a contract. Only the latest offers
-        per product and domain the are taken into account.
       tags:
-      - offers
-      - internal
+        - offers
+        - internal
+      summary: Get offer statistics per product of a contract
+      description: Get offer statistics per product of a contract. Only the latest offers per product and domain the are taken into account.
   /api/v3/manufacturer/contracts/{contractId}/products:
-    delete:
-      operationId: deleteProductsManufacturerV3
+    put:
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: updatedMax
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
+        - $ref: '#/components/parameters/contractIdParam'
+        - in: header
+          name: content-type
+          required: true
+          example: text/csv
+          schema:
+            enum:
+              - text/csv
+              - text/comma-separated-values
+              - text/csv; charset=UTF-8
+              - text/comma-separated-values; charset=UTF-8
+            type: string
+        - description: Comma separated list of csv columns that identify a product uniquely
+          in: header
+          name: patagona-product-identifying-attributes
+          required: true
+          example: id-column
+          schema:
+            type: string
+        - description: Csv column that contains the product name
+          in: header
+          name: patagona-product-name
+          required: true
+          example: name-column
+          schema:
+            type: string
+        - description: Csv column that contains the reference price
+          in: header
+          name: patagona-product-reference-price
+          required: true
+          example: reference-price-column
+          schema:
+            type: string
+        - description: Csv column that contains the gtin
+          in: header
+          name: patagona-product-gtin
+          example: gtin-column
+          schema:
+            type: string
+        - description: Csv column that contains an id (There is no requirement for this field to be unique)
+          in: header
+          name: patagona-product-customer-id
+          example: id-column
+          schema:
+            type: string
+        - description: |-
+            Decimal separator used for parsing numbers \
+            The values for patagona-decimal-separator, patagona-csv-column-separator and patagona-csv-quotation-character must be different from one another. \
+            Available values: ",", "."
+          in: header
+          example: .
+          name: patagona-decimal-separator
+          required: true
+          schema:
+            type: string
+        - description: |-
+            The csv column separator \
+            The values for patagona-decimal-separator, patagona-csv-column-separator and patagona-csv-quotation-character must be different from one another.
+          in: header
+          example: ','
+          name: patagona-csv-column-separator
+          required: true
+          schema:
+            type: string
+        - description: |-
+            The csv quotation character \
+            The values for patagona-decimal-separator, patagona-csv-column-separator and patagona-csv-quotation-character must be different from one another.
+          in: header
+          example: '"'
+          name: patagona-csv-quotation-character
+          required: true
+          schema:
+            type: string
       responses:
-        "200":
+        '202':
           content:
             application/json:
               schema:
-                type: object
-          description: This is a generated entry and needs to be described.
+                $ref: '#/components/schemas/PutProductsApiResponse'
+          description: |-
+            The field data.url in the returned object allows to check the status of the import process. It will point to the endpoint GET /api/2/v/contracts/{contractId}/tasks/{taskId}. \
+            The field data.id is the task id corresponding to the product import.
       tags:
-      - internal
-      - undocumented
-      - products
-    put:
+        - products
       description: |-
         This operation is used to import products into the pricemonitor.
         This process is represented by a task, which is processed asynchronously.
@@ -1771,280 +1486,133 @@ paths:
         Warning: All products that were in the pricemonitor before but are not present in the new import will be deleted.
 
         Identification of the products is done based on the identifying attributes (see parameter: patagona-product-identifying-attributes)
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - example: text/csv
-        explode: false
-        in: header
-        name: content-type
-        required: true
-        schema:
-          enum:
-          - text/csv
-          - text/comma-separated-values
-          - text/csv; charset=UTF-8
-          - text/comma-separated-values; charset=UTF-8
-          type: string
-        style: simple
-      - description: Comma separated list of csv columns that identify a product uniquely
-        example: id-column
-        explode: false
-        in: header
-        name: patagona-product-identifying-attributes
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Csv column that contains the product name
-        example: name-column
-        explode: false
-        in: header
-        name: patagona-product-name
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Csv column that contains the reference price
-        example: reference-price-column
-        explode: false
-        in: header
-        name: patagona-product-reference-price
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Csv column that contains the gtin
-        example: gtin-column
-        explode: false
-        in: header
-        name: patagona-product-gtin
-        required: false
-        schema:
-          type: string
-        style: simple
-      - description: Csv column that contains an id (There is no requirement for this
-          field to be unique)
-        example: id-column
-        explode: false
-        in: header
-        name: patagona-product-customer-id
-        required: false
-        schema:
-          type: string
-        style: simple
-      - description: |-
-          Decimal separator used for parsing numbers \
-          The values for patagona-decimal-separator, patagona-csv-column-separator and patagona-csv-quotation-character must be different from one another. \
-          Available values: ",", "."
-        example: "."
-        explode: false
-        in: header
-        name: patagona-decimal-separator
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: |-
-          The csv column separator \
-          The values for patagona-decimal-separator, patagona-csv-column-separator and patagona-csv-quotation-character must be different from one another.
-        example: ','
-        explode: false
-        in: header
-        name: patagona-csv-column-separator
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: |-
-          The csv quotation character \
-          The values for patagona-decimal-separator, patagona-csv-column-separator and patagona-csv-quotation-character must be different from one another.
-        example: '"'
-        explode: false
-        in: header
-        name: patagona-csv-quotation-character
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           text/csv:
             schema:
               type: string
-        description: 'CSV file containing the products. Note: The CSV file should
-          be encoded in UTF-8.'
+        description: 'CSV file containing the products. Note: The CSV file should be encoded in UTF-8.'
         required: true
+      summary: Set products via CSV file
+    delete:
+      x-audience: Internal
       responses:
-        "202":
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PutProductsApiResponse'
-          description: |-
-            The field data.url in the returned object allows to check the status of the import process. It will point to the endpoint GET /api/2/v/contracts/{contractId}/tasks/{taskId}. \
-            The field data.id is the task id corresponding to the product import.
-      summary: Set products via CSV file
+                type: object
+          description: This is a generated entry and needs to be described.
       tags:
-      - products
+        - internal
+        - undocumented
+        - products
+      operationId: deleteProductsManufacturerV3
+      parameters:
+        - in: query
+          name: updatedMax
+          required: false
+          schema:
+            type: string
+            format: date-time
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/v3/vendor/contracts/{contractId}/offers:
     get:
+      summary: Get offers for timerange
       description: Returns the newest offers for a given time range.
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Where to start fetching the products
-        example: 0
-        explode: true
-        in: query
-        name: start
-        required: false
-        schema:
-          default: 0
-          format: int32
-          type: integer
-        style: form
-      - description: Maximum number of results
-        example: 1000
-        explode: true
-        in: query
-        name: limit
-        required: false
-        schema:
-          default: 1000
-          format: int32
-          type: integer
-        style: form
-      - description: Whether to return tags of products or not.
-        explode: true
-        in: query
-        name: includeTags
-        required: false
-        schema:
-          default: true
-          type: boolean
-        style: form
-      - description: Timestamp of start of time range, formatted as ISO Date (i.e.
-          2018-04-06T13:46:13Z) in UTC. If this value is omitted and {endDate} is
-          given, {startDate} is set to {endDate} - 48 hours. If both values are omitted,
-          the range is 'NOW - 48 hours to NOW'.
-        explode: true
-        in: query
-        name: startDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - description: Timestamp of end of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z)
-          in UTC. If this value is omitted and {startDate} is given, {endDate} is
-          set to {startDate} + 48 hours. If both values are omitted, the range is
-          'NOW - 48 hours to NOW'.
-        explode: true
-        in: query
-        name: endDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
+        - $ref: '#/components/parameters/contractIdParam'
+        - description: Where to start fetching the products
+          in: query
+          name: start
+          required: false
+          example: 0
+          schema:
+            default: 0
+            format: int32
+            type: integer
+        - description: Maximum number of results
+          in: query
+          name: limit
+          required: false
+          example: 1000
+          schema:
+            default: 1000
+            format: int32
+            type: integer
+        - description: Whether to return tags of products or not.
+          in: query
+          name: includeTags
+          required: false
+          schema:
+            default: true
+            type: boolean
+        - $ref: '#/components/parameters/startDate'
+        - $ref: '#/components/parameters/endDate'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetOffersApiResponse'
           description: A list of products with their corresponding offers.
-        "400":
+        '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiError'
-          description: Returned in case of invalid time range or a limit greater than
-            10000.
+          description: Returned in case of invalid time range or a limit greater than 10000.
       tags:
-      - offers
+        - offers
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/v3/vendor/contracts/{contractId}/offers/shops:
+    x-audience: Internal
     get:
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Timestamp of start of time range, formatted as ISO Date (i.e.
-          2018-04-06T13:46:13Z) in UTC. If this value is omitted and {endDate} is
-          given, {startDate} is set to {endDate} - 48 hours. If both values are omitted,
-          the range is 'NOW - 48 hours to NOW'. The time range may not exceed 1 week.
-        explode: true
-        in: query
-        name: startDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - description: Timestamp of end of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z)
-          in UTC. If this value is omitted and {startDate} is given, {endDate} is
-          set to {startDate} + 48 hours. If both values are omitted, the range is
-          'NOW - 48 hours to NOW'. The time range may not exceed 1 week.
-        explode: true
-        in: query
-        name: endDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
+        - $ref: '#/components/parameters/contractIdParam'
+        - $ref: '#/components/parameters/startDateOneWeekMax'
+        - $ref: '#/components/parameters/endDateOneWeekMax'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetShopsByDomainResponseV3ApiResponse'
-          description: Shops which have at least one offer for a given time range
-            per domain.
-        "400":
+          description: Shops which have at least one offer for a given time range per domain.
+        '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiError'
           description: Specified time range is invalid (> 7 days).
-      summary: Returns all shops which have at least one offer for a given time range
-        per domain.
       tags:
-      - offers
-      - internal
+        - offers
+        - internal
+      summary: Get shops with offers for time range per domain
+      description: Returns all shops which have at least one offer for a given time range per domain.
   /api/v3/vendor/contracts/{contractId}/offers/query:
     post:
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - $ref: '#/components/parameters/contractIdParam'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryOffersApiResponse'
+          description: Returns either an Error or a list of ApiOffers matching the given filter.
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+          description: Returned in case of unparsable request JSON or unsupported filter/sorting.
+      tags:
+        - offers
+      summary: Query offers
+      description: Supports complex queries for offers.
       requestBody:
         content:
           application/json:
@@ -2073,109 +1641,56 @@ paths:
 
           Note: This endpoint will only return the newest offers for each product for a given time range.
         required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/QueryOffersApiResponse'
-          description: Returns either an Error or a list of ApiOffers matching the
-            given filter.
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiError'
-          description: Returned in case of unparsable request JSON or unsupported
-            filter/sorting.
-      tags:
-      - offers
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/v3/vendor/contracts/{contractId}/offers/shop/query:
+    x-audience: Internal
     post:
-      description: Get all offers of a shop. Please note that it might return offers
-        for inactive products.
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - $ref: '#/components/parameters/contractIdParam'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryOffersOfShopV3ApiResponse'
+          description: Returns offers of the shop
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.QueryOffersOfShopRequestV3'
         required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/QueryOffersOfShopV3ApiResponse'
-          description: Returns offers of the shop
       tags:
-      - products
-      - internal
+        - products
+        - internal
+      description: Get all offers of a shop. Please note that it might return offers for inactive products.
   /api/v3/vendor/contracts/{contractId}/offers/pricedumpingstats:
     post:
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - $ref: '#/components/parameters/contractIdParam'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryPriceDumpingStatsApiResponse'
+          description: Returns the price dumping statistics in the given time range.
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PriceDumpingStatsRequest'
         required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/QueryPriceDumpingStatsApiResponse'
-          description: Returns the price dumping statistics in the given time range.
       tags:
-      - products
+        - products
   /api/v3/vendor/contracts/{contractId}/offers/stats/query:
+    x-audience: Internal
     post:
-      description: |
-        This operation is used to get offer statistics (e.g. offer count, average price) grouped by product and domain.
-
-        Warning: This endpoint contains complex filter structure and will be replaced in the future. Currently, we only allow filtering by a list of internal pricemonitor product ids. Please note that offer statistics can only be computed for at **maximum 2500** products at a time.
-
-        To use the example request body from below, you have to adjust the `ownShopNames`, the `range` and `filter.right.value`. Where `filter.right.value` has to be a list of internal pricemonitor product ids corresponding to the `contractId` provided as part of the URL.
-
-        All prices will be with or without delivery costs depending on the `includeDeliveryCosts` parameter in the body.
-      operationId: postOfferStatisticsVendorQuery
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PostOfferStatisticsRequest'
-        required: true
+        - $ref: '#/components/parameters/contractIdParam'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
@@ -2195,36 +1710,37 @@ paths:
             The offer count of one product in the total market is the sum of the offer counts for all its domains. In the example below, both products would have an offer count of `12 + 4 = 16`.
             ### Market Position
             The market position of a product generally **can not be deduced** from the data provided in this endpoint.
-        "400":
+        '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiError'
-          description: Returned in case of unparsable request body JSON or unsupported
-            filter.
+          description: Returned in case of unparsable request body JSON or unsupported filter.
       tags:
-      - products
-      - internal
+        - products
+        - internal
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PostOfferStatisticsRequest'
+        required: true
+      operationId: postOfferStatisticsVendorQuery
+      description: |
+        This operation is used to get offer statistics (e.g. offer count, average price) grouped by product and domain.
+
+        Warning: This endpoint contains complex filter structure and will be replaced in the future. Currently, we only allow filtering by a list of internal pricemonitor product ids. Please note that offer statistics can only be computed for at **maximum 2500** products at a time.
+
+        To use the example request body from below, you have to adjust the `ownShopNames`, the `range` and `filter.right.value`. Where `filter.right.value` has to be a list of internal pricemonitor product ids corresponding to the `contractId` provided as part of the URL.
+
+        All prices will be with or without delivery costs depending on the `includeDeliveryCosts` parameter in the body.
     summary: Get offer statistics per product
   /api/v3.1/vendor/contracts/{contractId}/offers/stats/query:
     post:
-      description: This endpoint can be used to query offer statistics (e.g. offer
-        count, average price) grouped by product. Only the most recent market data
-        is considered per product and domain.
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        $ref: '#/components/requestBodies/PostOfferStatisticsRequestV31Enriched'
+        - $ref: '#/components/parameters/contractIdParam'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
@@ -2232,7 +1748,7 @@ paths:
           description: |
             Returns a list of offer statistics per product.
             When a product has no market data then no offer statistics are returned for that product.
-        "400":
+        '400':
           content:
             application/json:
               schema:
@@ -2243,95 +1759,27 @@ paths:
             - An unsupported filter is provided.
             - The specified time range exceeds 48 hours.
             - The pagination limit exceeds 10,000.
-      summary: Query offer statistics per product.
       tags:
-      - offers
+        - offers
+      requestBody:
+        $ref: '#/components/requestBodies/PostOfferStatisticsRequestV31Enriched'
+      description: This endpoint can be used to query offer statistics (e.g. offer count, average price) grouped by product. Only the most recent market data is considered per product and domain.
+      summary: Query offer statistics per product
   /api/v3/vendor/contracts/{contractId}/orders:
     delete:
-      operationId: deleteOrders
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - $ref: '#/components/parameters/contractIdParam'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeletedItemsApiResponse'
           description: Successfully deleted all orders
+      tags:
+        - orders
+      operationId: deleteOrders
       summary: Delete all orders for this contract
-      tags:
-      - orders
-    get:
-      operationId: getOrdersVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: start
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
-      - explode: true
-        in: query
-        name: limit
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
-      - description: |
-          Timestamp of start of time range for fetching orders.
-          Formatted as ISO 8601 format with timezone with reference to UTC (e.g. for [Europe/Berlin] in winter time:
-          2023-11-01T14:50:45.495+01:00. In summer time: 2023-11-01T14:50:45.495+02:00).
-          If this value is omitted then no lower time limit is considered.
-        explode: true
-        in: query
-        name: startDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - description: |
-          Timestamp of end of time range for fetching orders.
-          Formatted as ISO 8601 format with timezone with reference to UTC (e.g. for [Europe/Berlin] in winter time:
-          2023-11-01T14:50:45.495+01:00. In summer time: 2023-11-01T14:50:45.495+02:00).
-          If this value is omitted then no upper time limit is considered.
-        explode: true
-        in: query
-        name: endDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - orders
     put:
       description: |
         Saves orders in bulk. If an orderId was already used by this contract this order and all it's order-items will
@@ -2343,98 +1791,130 @@ paths:
         - each order must have at least one item
         - the `orders.items.itemId` fields should correspond to a `customerProductId` of a product definition inside
           the contract
-      operationId: putOrdersV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
+            schema:
+              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PutCustomerOrdersRequestV3'
             example:
               orders:
                 shippingCosts: 5.9
                 orderId: 2023-11_customer-a_001
                 items:
-                - unitPrice: 6.02
-                  itemId: itemId
-                  quantity: 1
-                  taxPercentage: 19
+                  - unitPrice: 6.02
+                    itemId: itemId
+                    quantity: 1
+                    taxPercentage: 19
                 totalPrice: 11.92
                 origin: Amazon.de
-                creationDate: 2023-11-23T11:20:21.034+01:00
+                creationDate: '2023-11-23T11:20:21.034+01:00'
                 currency: EUR
               version: 3
-            schema:
-              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PutCustomerOrdersRequestV3'
       responses:
-        "201":
+        '201':
+          description: The response provides the ids of the successfully imported orders
           content:
             application/json:
+              schema:
+                $ref: '#/components/schemas/PutItemsV3ApiResponse'
               example:
                 data:
                   ids:
-                  - OrderId-1
-                  - OrderId-2
-              schema:
-                $ref: '#/components/schemas/PutItemsV3ApiResponse'
-          description: The response provides the ids of the successfully imported
-            orders
-        "400":
+                    - OrderId-1
+                    - OrderId-2
+        '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
           description: Unable to add orders because of invalid request data
-      summary: PUT orders in bulk
       tags:
-      - orders
+        - orders
+      operationId: putOrdersV3
+      summary: PUT orders in bulk
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - orders
+      operationId: getOrdersVendorV3
+      description: Returns all orders for a given contract.
+      summary: Get all orders
+      parameters:
+        - in: query
+          name: start
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - $ref: '#/components/parameters/getOrdersStartDate'
+        - $ref: '#/components/parameters/getOrdersEndDate'
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/v3/vendor/contracts/{contractId}/orders/stats/query:
     post:
-      description: This endpoint can be used to query order statistics grouped by
-        product.
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - $ref: '#/components/parameters/contractIdParam'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryOrderStatisticsV3ApiResponse'
+          description: |
+            Returns a list of order statistics per product.
+            When a product has no sold items then no order statistics are returned for that product.
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: |
+            A `400` error is returned under the following conditions:
+            - The request body JSON is unparsable.
+            - An unsupported filter is provided.
+            - The specified time range exceeds 30 days.
+            - The pagination limit exceeds 10,000.
+      tags:
+        - orders
       requestBody:
         content:
           application/json:
+            schema:
+              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostOrderStatisticsRequestV3'
             example:
               pagination:
                 start: 0
                 limit: 10
               range:
-                start: 2023-11-01T08:00:00Z
-                end: 2023-11-15T08:00:00Z
+                start: '2023-11-01T08:00:00Z'
+                end: '2023-11-15T08:00:00Z'
               filter:
                 oneOf:
                   field: customerProductId
                   values:
-                  - "1"
-                  - "2"
-                  - "3"
-                  - "4"
-                  - "5"
-                  - "6"
-                  - "7"
-                  - "8"
-                  - "9"
-                  - "10"
-            schema:
-              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostOrderStatisticsRequestV3'
+                    - '1'
+                    - '2'
+                    - '3'
+                    - '4'
+                    - '5'
+                    - '6'
+                    - '7'
+                    - '8'
+                    - '9'
+                    - '10'
+        required: true
         description: |
           The request body may include an optional products query. If omitted, all products are queried. Currently, product queries can be performed on two attributes:
             - "customerProductId"
@@ -2466,17 +1946,21 @@ paths:
           &nbsp;&nbsp;} <br>
           } <br>
           <br>
-        required: true
+      description: This endpoint can be used to query order statistics grouped by product.
+      summary: Query order statistics per product
+  /api/v3/vendor/contracts/{contractId}/orders/delete/query:
+    post:
+      parameters:
+        - $ref: '#/components/parameters/contractIdParam'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/QueryOrderStatisticsV3ApiResponse'
+                $ref: '#/components/schemas/DeletedItemsApiResponse'
           description: |
-            Returns a list of order statistics per product.
-            When a product has no sold items then no order statistics are returned for that product.
-        "400":
+            Returns the number of orders that have been deleted successfully
+        '400':
           content:
             application/json:
               schema:
@@ -2484,35 +1968,19 @@ paths:
           description: |
             A `400` error is returned under the following conditions:
             - The request body JSON is unparsable.
-            - An unsupported filter is provided.
-            - The specified time range exceeds 30 days.
-            - The pagination limit exceeds 10,000.
-      summary: Query order statistics per product
+            - The provided order queries exceeds 10,000.
       tags:
-      - orders
-  /api/v3/vendor/contracts/{contractId}/orders/delete/query:
-    post:
-      description: This endpoint can be used to delete customer orders by an order
-        query
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - orders
       requestBody:
         content:
           application/json:
-            example:
-              orders:
-              - orderId: "123"
-                creationDate: 2023-11-01T08:00:00Z
             schema:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.DeleteOrdersByQueryRequestV3'
+            example:
+              orders:
+                - orderId: '123'
+                  creationDate: '2023-11-01T08:00:00Z'
+        required: true
         description: |
           The request body should contain a list of order queries. Each query should contain an order id and creation date.
 
@@ -2527,154 +1995,111 @@ paths:
           &nbsp;&nbsp;&nbsp;] <br>
           } <br>
           <br>
-        required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DeletedItemsApiResponse'
-          description: |
-            Returns the number of orders that have been deleted successfully
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: |
-            A `400` error is returned under the following conditions:
-            - The request body JSON is unparsable.
-            - The provided order queries exceeds 10,000.
+      description: This endpoint can be used to delete customer orders by an order query
       summary: Delete orders by query
-      tags:
-      - orders
   /api/v3/vendor/contracts/{contractId}/products:
-    delete:
-      description: Delete all products or delete products by a last updated timestamp.
-      operationId: deleteProducts
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Last updated timestamp of products, formatted as ISO Date (i.e.
-          2019-11-20T13:46:13Z) in UTC.<br> Products can be deleted which haven't
-          been updated since the specified timestamp.<br> If the query parameter is
-          missing all products are deleted.
-        explode: true
-        in: query
-        name: updatedMax
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - description: Tag key to consider for deleting products. This parameter works
-          in combination with tagValue.
-        explode: true
-        in: query
-        name: tagKey
-        required: false
-        schema:
-          type: string
-        style: form
-      - description: Tag value to consider for deleting products. This parameter works
-          in combination with tagKey.
-        explode: true
-        in: query
-        name: tagValue
-        required: false
-        schema:
-          type: string
-        style: form
-      responses:
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: |
-            Tags specified for deleting products are specified partially (either tagKey or tagValue is provided).
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DeleteProductsApiResponse'
-          description: Returns the number of deleted products.
-      summary: Delete products
-      tags:
-      - products
-    post:
-      description: |-
-        This operation is used to import products into the pricemonitor:<br>
-        Products that are already present will be updated and new products will be added. Identification of the products is done based on the identifying attributes, which need to be provided via the request body.<br><br>
-        Attention:<br> This endpoint should only be used when dealing with large number of products at your side is an issue. Otherwise please use the PUT-counterpart of this endpoint which accepts products via a csv file.<br><br>
-        Note:<br> This endpoint should be used in conjunction with: DELETE  /api/v3/vendor/contracts/{contractId}/products.<br><br>
-        Procedure:<br> 1. Add your products in bulks with multiple requests via this endpoint.<br> 2. Send a DELETE request to /api/v3/vendor/contracts/{contractId}/products
-           and set the parameter updatedMax to a date which is older or equal to your first request from step 1.
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - example: application/json
-        explode: false
-        in: header
-        name: content-type
-        required: true
-        schema:
-          enum:
-          - application/json
-          type: string
-        style: simple
-      - description: 'The decimal separator is used for parsing numbers in tags. English
-          and German number formats are supported: dot and comma.'
-        example: "."
-        explode: false
-        in: header
-        name: patagona-tags-decimal-separator
-        required: true
-        schema:
-          enum:
-          - "."
-          - ','
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PostProductsRequest'
-        description: The body contains the products which should be added
-        required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BulkedPostProductsApiResponse'
-          description: The response provides sorted import results in respective to
-            the order of the provided products.
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: Unable to add products because of invalid request data
-      summary: Add products in bulk
-      tags:
-      - products
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
     put:
+      parameters:
+        - in: header
+          name: content-type
+          required: true
+          example: text/csv
+          schema:
+            enum:
+              - text/csv
+              - text/comma-separated-values
+              - text/csv; charset=UTF-8
+              - text/comma-separated-values; charset=UTF-8
+            type: string
+        - description: Comma separated list of csv columns that identify a product uniquely
+          in: header
+          name: patagona-product-identifying-attributes
+          required: true
+          example: id-column
+          schema:
+            type: string
+        - description: Csv column that contains the product name
+          in: header
+          name: patagona-product-name
+          required: true
+          example: name-column
+          schema:
+            type: string
+        - description: Csv column that contains the reference price
+          in: header
+          name: patagona-product-reference-price
+          required: true
+          example: reference-price-column
+          schema:
+            type: string
+        - description: Csv column that contains the min price
+          in: header
+          name: patagona-product-min-price
+          required: true
+          example: min-price-column
+          schema:
+            type: string
+        - description: Csv column that contains the max price
+          in: header
+          name: patagona-product-max-price
+          required: true
+          example: max-price-column
+          schema:
+            type: string
+        - description: Csv column that contains the gtin
+          in: header
+          name: patagona-product-gtin
+          example: max-price-column
+          schema:
+            type: string
+        - description: Csv column that contains an id (There is no requirement for this field to be unique)
+          in: header
+          name: patagona-product-customer-id
+          example: id-column
+          schema:
+            type: string
+        - description: |-
+            Decimal separator used for parsing numbers \
+            The values for patagona-decimal-separator, patagona-csv-column-separator and patagona-csv-quotation-character must be different from one another. \
+            Available values: ",", "."
+          in: header
+          name: patagona-decimal-separator
+          example: .
+          required: true
+          schema:
+            type: string
+        - description: |-
+            The csv column separator \
+            It can be provided either as text or as Base64 encoded string (e.g. needed for tab as separator). \
+            The values for patagona-decimal-separator, patagona-csv-column-separator and patagona-csv-quotation-character must be different from one another.
+          in: header
+          name: patagona-csv-column-separator
+          example: ','
+          required: true
+          schema:
+            type: string
+        - description: |-
+            The csv quotation character \
+            The values for patagona-decimal-separator, patagona-csv-column-separator and patagona-csv-quotation-character must be different from one another.
+          in: header
+          name: patagona-csv-quotation-character
+          example: '"'
+          required: true
+          schema:
+            type: string
+      responses:
+        '202':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PutProductsApiResponse'
+          description: |-
+            The field data.url in the returned object allows to check the status of the import process. It will point to the endpoint GET /api/2/v/contracts/{contractId}/tasks/{taskId}. \
+            The field data.id is the task id corresponding to the product import.
+      tags:
+        - products
       description: |-
         This operation is used to import products into the pricemonitor.
         This process is represented by a task, which is processed asynchronously.
@@ -2686,2270 +2111,1664 @@ paths:
         Warning: All products that were in the pricemonitor before but are not present in the new import will be deleted.
 
         Identification of the products is done based on the identifying attributes (see parameter: patagona-product-identifying-attributes)
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - example: text/csv
-        explode: false
-        in: header
-        name: content-type
-        required: true
-        schema:
-          enum:
-          - text/csv
-          - text/comma-separated-values
-          - text/csv; charset=UTF-8
-          - text/comma-separated-values; charset=UTF-8
-          type: string
-        style: simple
-      - description: Comma separated list of csv columns that identify a product uniquely
-        example: id-column
-        explode: false
-        in: header
-        name: patagona-product-identifying-attributes
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Csv column that contains the product name
-        example: name-column
-        explode: false
-        in: header
-        name: patagona-product-name
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Csv column that contains the reference price
-        example: reference-price-column
-        explode: false
-        in: header
-        name: patagona-product-reference-price
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Csv column that contains the min price
-        example: min-price-column
-        explode: false
-        in: header
-        name: patagona-product-min-price
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Csv column that contains the max price
-        example: max-price-column
-        explode: false
-        in: header
-        name: patagona-product-max-price
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Csv column that contains the gtin
-        example: max-price-column
-        explode: false
-        in: header
-        name: patagona-product-gtin
-        required: false
-        schema:
-          type: string
-        style: simple
-      - description: Csv column that contains an id (There is no requirement for this
-          field to be unique)
-        example: id-column
-        explode: false
-        in: header
-        name: patagona-product-customer-id
-        required: false
-        schema:
-          type: string
-        style: simple
-      - description: |-
-          Decimal separator used for parsing numbers \
-          The values for patagona-decimal-separator, patagona-csv-column-separator and patagona-csv-quotation-character must be different from one another. \
-          Available values: ",", "."
-        example: "."
-        explode: false
-        in: header
-        name: patagona-decimal-separator
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: |-
-          The csv column separator \
-          It can be provided either as text or as Base64 encoded string (e.g. needed for tab as separator). \
-          The values for patagona-decimal-separator, patagona-csv-column-separator and patagona-csv-quotation-character must be different from one another.
-        example: ','
-        explode: false
-        in: header
-        name: patagona-csv-column-separator
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: |-
-          The csv quotation character \
-          The values for patagona-decimal-separator, patagona-csv-column-separator and patagona-csv-quotation-character must be different from one another.
-        example: '"'
-        explode: false
-        in: header
-        name: patagona-csv-quotation-character
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           text/csv:
             schema:
               type: string
-        description: 'CSV file containing the products. Note: The CSV file should
-          be encoded in UTF-8.'
+        description: 'CSV file containing the products. Note: The CSV file should be encoded in UTF-8.'
         required: true
+      summary: Set products via CSV file
+    post:
+      parameters:
+        - in: header
+          name: content-type
+          required: true
+          example: application/json
+          schema:
+            enum:
+              - application/json
+            type: string
+        - in: header
+          name: patagona-tags-decimal-separator
+          description: 'The decimal separator is used for parsing numbers in tags. English and German number formats are supported: dot and comma.'
+          required: true
+          example: .
+          schema:
+            type: string
+            enum:
+              - .
+              - ','
       responses:
-        "202":
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PutProductsApiResponse'
-          description: |-
-            The field data.url in the returned object allows to check the status of the import process. It will point to the endpoint GET /api/2/v/contracts/{contractId}/tasks/{taskId}. \
-            The field data.id is the task id corresponding to the product import.
-      summary: Set products via CSV file
+                $ref: '#/components/schemas/BulkedPostProductsApiResponse'
+          description: The response provides sorted import results in respective to the order of the provided products.
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Unable to add products because of invalid request data
       tags:
-      - products
+        - products
+      description: |-
+        This operation is used to import products into the pricemonitor:<br>
+        Products that are already present will be updated and new products will be added. Identification of the products is done based on the identifying attributes, which need to be provided via the request body.<br><br>
+        Attention:<br> This endpoint should only be used when dealing with large number of products at your side is an issue. Otherwise please use the PUT-counterpart of this endpoint which accepts products via a csv file.<br><br>
+        Note:<br> This endpoint should be used in conjunction with: DELETE  /api/v3/vendor/contracts/{contractId}/products.<br><br>
+        Procedure:<br> 1. Add your products in bulks with multiple requests via this endpoint.<br> 2. Send a DELETE request to /api/v3/vendor/contracts/{contractId}/products
+           and set the parameter updatedMax to a date which is older or equal to your first request from step 1.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PostProductsRequest'
+        description: The body contains the products which should be added
+        required: true
+      summary: Add products in bulk
+    delete:
+      parameters:
+        - in: query
+          name: updatedMax
+          description: Last updated timestamp of products, formatted as ISO Date (i.e. 2019-11-20T13:46:13Z) in UTC.<br> Products can be deleted which haven't been updated since the specified timestamp.<br> If the query parameter is missing all products are deleted.
+          required: false
+          schema:
+            format: date-time
+            type: string
+        - in: query
+          name: tagKey
+          description: Tag key to consider for deleting products. This parameter works in combination with tagValue.
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: tagValue
+          description: Tag value to consider for deleting products. This parameter works in combination with tagKey.
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteProductsApiResponse'
+          description: Returns the number of deleted products.
+        '400':
+          description: |
+            Tags specified for deleting products are specified partially (either tagKey or tagValue is provided).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - products
+      operationId: deleteProducts
+      description: Delete all products or delete products by a last updated timestamp.
+      summary: Delete products
   /api/v3/vendor/contracts/{contractId}/products/{productId}/extendedtags:
     get:
-      operationId: getExtendedTags
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: ID of the product
-        example: 1
-        explode: false
-        in: path
-        name: productId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - $ref: '#/components/parameters/contractIdParam'
+        - description: ID of the product
+          in: path
+          name: productId
+          required: true
+          example: 1
+          schema:
+            type: string
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetExtendedTagsApiResponse'
           description: Returns a list of ExtendedTags for the given product.
-        "404":
+        '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
           description: Given product does not exist.
+      tags:
+        - products
+      operationId: getExtendedTags
       summary: Return the extended tags for the given product
-      tags:
-      - products
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
+        name: productId
+        required: true
+        schema:
+          type: string
   /api/v3/vendor/contracts/{contractId}/plugin:
-    delete:
-      operationId: deletePluginRegistration
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PluginRegistrationEmptyApiResponse'
-          description: Plugin registration for given contract deleted successfully.
-      summary: Delete the plugin registration for given contract
-      tags:
-      - pluginregistration
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
     get:
-      operationId: getPluginRegistration
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/PluginRegistrationApiResponse'
           description: Returns a plugin registration for given contract.
-        "404":
+        '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
           description: Given plugin registration does not exist.
-      summary: Return the plugin registration for given contract
       tags:
-      - pluginregistration
+        - pluginregistration
+      operationId: getPluginRegistration
+      summary: Return the plugin registration for given contract
     put:
-      operationId: putPluginRegistration
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PutPluginRegistrationRequest'
-        required: true
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/PluginRegistrationEmptyApiResponse'
           description: Plugin registration for given contract stored successfully.
-      summary: Create and/or update the plugin registration for given contract
       tags:
-      - pluginregistration
+        - pluginregistration
+      operationId: putPluginRegistration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PutPluginRegistrationRequest'
+      summary: Create and/or update the plugin registration for given contract
+    delete:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PluginRegistrationEmptyApiResponse'
+          description: Plugin registration for given contract deleted successfully.
+      tags:
+        - pluginregistration
+      operationId: deletePluginRegistration
+      summary: Delete the plugin registration for given contract
   /api/v3/log/messages:
     post:
+      responses:
+        '200':
+          description: The logs have been stored successfully.
+      tags:
+        - logs
       operationId: postLogMessages
       requestBody:
+        required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/LogMessages'
-        required: true
-      responses:
-        "200":
-          description: The logs have been stored successfully.
-      summary: Stores the log messages. This endpoint aims to improve the API-integration
-        process. One could integrate the Pricemonitor API in his/her own system and
-        publish the integration logs so that Patagona could analyze them.
-      tags:
-      - logs
+      summary: Store log messages
+      description: Stores log messages in the platform. This endpoint aims to improve the API integration process.
   /controlpanel/api/companies:
+    x-audience: Internal
     get:
-      parameters:
-      - description: Start of the pagination
-        explode: true
-        in: query
-        name: start
-        required: false
-        schema:
-          default: 0
-          format: int32
-          type: integer
-        style: form
-      - description: Number of elements per page
-        explode: true
-        in: query
-        name: limit
-        required: false
-        schema:
-          default: 100
-          format: int32
-          type: integer
-        style: form
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.AdminCompanyV2'
           description: A list of companies was loaded
-      summary: Get a list of all companies
+      parameters:
+        - in: query
+          name: start
+          description: Start of the pagination
+          schema:
+            default: 0
+            format: int32
+            type: integer
+        - in: query
+          name: limit
+          description: Number of elements per page
+          schema:
+            default: 100
+            format: int32
+            type: integer
       tags:
-      - internal
-      - controlpanel
+        - internal
+        - controlpanel
+      summary: Get a list of all companies
     post:
-      operationId: addCompany
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - controlpanel
+        - internal
+        - undocumented
+        - controlpanel
+      operationId: addCompany
   /controlpanel/api/contracts:
+    x-audience: Internal
     get:
-      operationId: getAllContracts
       responses:
-        "200":
+        '200':
           description: A list of contracts was loaded
+      tags:
+        - internal
+        - undocumented
+        - controlpanel
       summary: Get a list of all contracts
-      tags:
-      - internal
-      - undocumented
-      - controlpanel
+      operationId: getAllContracts
   /controlpanel/api/portals:
+    x-audience: Internal
     get:
-      operationId: getAllPortals
       responses:
-        "200":
+        '200':
           description: A list of portals was loaded
+      tags:
+        - internal
+        - undocumented
+        - controlpanel
       summary: Get a list of all portals
-      tags:
-      - internal
-      - undocumented
-      - controlpanel
+      operationId: getAllPortals
   /controlpanel/api/users:
+    x-audience: Internal
     get:
-      operationId: getAllUsers
       responses:
-        "200":
+        '200':
           description: A list of users was loaded
-      summary: Get a list of all users
       tags:
-      - internal
-      - undocumented
-      - controlpanel
+        - internal
+        - undocumented
+        - controlpanel
+      summary: Get a list of all users
+      operationId: getAllUsers
   /controlpanel/users:
+    x-audience: Internal
     post:
-      operationId: addUser
+      responses:
+        '200':
+          description: A new user was added
+        '400':
+          description: A new user was not added
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/NewUser'
         description: The new user to be added
-      responses:
-        "200":
-          description: A new user was added
-        "400":
-          description: A new user was not added
-      summary: Add a new user
       tags:
-      - internal
-      - controlpanel
+        - internal
+        - controlpanel
+      summary: Add a new user
+      operationId: addUser
   /api/1/{contractId}/products/analysis/timestamps:
+    x-audience: Internal
     get:
-      operationId: getTimeStamps
-      parameters:
-      - explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          format: int64
-          type: integer
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - pricerecommendations
+        - internal
+        - undocumented
+        - pricerecommendations
+      operationId: getTimeStamps
+    parameters:
+      - in: path
+        name: contractId
+        required: true
+        schema:
+          type: integer
+          format: int64
   /api/1/{contractId}/products/articlescountbyportal:
+    x-audience: Internal
     get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - offers
       operationId: getProductMetricsByContract
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: start
-        required: true
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: end
-        required: true
-        schema:
-          format: date-time
-          type: string
-        style: form
+        - in: query
+          name: start
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: end
+          required: true
+          schema:
+            type: string
+            format: date-time
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/1/{contractId}/products/offers:
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - offers
-  /api/1/{contractId}/products/offers:
-    get:
+        - internal
+        - undocumented
+        - offers
       operationId: rawOffers
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: start
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
-      - explode: true
-        in: query
-        name: limit
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
-      - explode: true
-        in: query
-        name: since
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: until
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - offers
+        - in: query
+          name: start
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: since
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: until
+          required: false
+          schema:
+            type: string
+            format: date-time
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/1/{contractId}/products/orderscountbyportal:
+    x-audience: Internal
     get:
-      operationId: getOrdersCountByPortalByContract
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - orders
+        - internal
+        - undocumented
+        - orders
+      operationId: getOrdersCountByPortalByContract
+      summary: Get orders count by portal
+      description: Get the number of orders by portal for the given contract.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/1/{contractId}/settings:
+    x-audience: Internal
     get:
-      operationId: getSettings
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.GetContractSettingsResponseV1'
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
+        - internal
+        - undocumented
+        - settings
+      operationId: getSettings
     put:
-      operationId: putSettings
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PutAdminContractSettingsBody'
-        description: This is a generated entry and needs to be described.
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PutAdminContractSettingsBody'
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
+        - internal
+        - undocumented
+        - settings
+      operationId: putSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PutAdminContractSettingsBody'
+        description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/1/{contractId}/settings/alerts:
+    x-audience: Internal
     get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - settings
       operationId: getAlertSettings
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+    post:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
-    post:
+        - internal
+        - undocumented
+        - settings
       operationId: createAlertSettings
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/1/{contractId}/settings/alerts/{alertId}:
+    x-audience: Internal
     delete:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - settings
       operationId: deleteAlertSettings
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
-        name: alertId
-        required: true
-        schema:
-          type: string
-        style: simple
+    put:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
-    put:
+        - internal
+        - undocumented
+        - settings
       operationId: updateAlertSettings
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
         name: alertId
         required: true
         schema:
           type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
   /api/1/{contractId}/settings/dynamicmonitoring:
-    delete:
-      operationId: deleteDynamicMonitoringSettings
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
-    get:
+        - internal
+        - undocumented
+        - settings
       operationId: getDynamicMonitoringSettings
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
     put:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - settings
       operationId: putDynamicMonitoringSettings
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
+    delete:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
+        - internal
+        - undocumented
+        - settings
+      operationId: deleteDynamicMonitoringSettings
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/1/{contractId}/settings/include_delivery_costs:
+    x-audience: Internal
     post:
-      operationId: saveIncludeDeliveryCosts
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: This is a generated entry and needs to be described.
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
+        - internal
+        - undocumented
+        - settings
+      operationId: saveIncludeDeliveryCosts
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/1/{contractId}/tasks:
+    x-audience: Internal
     get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - tasks
       operationId: getTasks
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: tasks
-        required: true
-        schema:
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: attributes
-        required: true
-        schema:
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: limit
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
-      - explode: true
-        in: query
-        name: taskType
-        required: false
-        schema:
-          type: string
-        style: form
+        - in: query
+          name: tasks
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: attributes
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: taskType
+          required: false
+          schema:
+            type: string
+    post:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - tasks
-    post:
+        - internal
+        - undocumented
+        - tasks
       operationId: createTask
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CreateTaskBodyV2'
         description: Create a new task
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - tasks
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/1/{contractId}/tasks/{taskId}:
+    x-audience: Internal
     get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - tasks
       operationId: getTask
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
         name: taskId
         required: true
         schema:
           type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - tasks
   /api/1/{contractId}/tasks/{taskId}/state:
+    x-audience: Internal
     get:
-      operationId: getTaskState
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
-        name: taskId
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - tasks
+        - internal
+        - undocumented
+        - tasks
+      operationId: getTaskState
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
+        name: taskId
+        required: true
+        schema:
+          type: string
   /api/1/{contractId}/vendors/{vendor}/positions:
+    x-audience: Internal
     post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - offers
       operationId: positionDistribution
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
+        - in: query
+          name: day
+          required: true
+          schema:
+            type: string
+            format: date-time
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
         name: vendor
         required: true
         schema:
           type: string
-        style: simple
-      - explode: true
-        in: query
-        name: day
-        required: true
-        schema:
-          format: date-time
-          type: string
-        style: form
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - offers
   /api/2/m/contracts/{contractId}:
+    x-audience: Internal
     get:
-      operationId: getManufacturerManufacturerV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - companies
+        - internal
+        - undocumented
+        - companies
+      operationId: getManufacturerManufacturerV2
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/m/contracts/{contractId}/products/csv:
+    x-audience: Internal
     put:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - products
       operationId: putProductsCSVManufacturerV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - products
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/m/contracts/{contractId}/products/tags:
+    x-audience: Internal
     get:
-      operationId: getTagsManufacturerV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - products
+        - internal
+        - undocumented
+        - products
+      operationId: getTagsManufacturerV2
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/m/contracts/{contractId}/products/tags/{key}:
+    x-audience: Internal
     get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - products
       operationId: getTagValuesManufacturerV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
         name: key
         required: true
         schema:
           type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - products
   /api/2/m/contracts/{contractId}/result/contract/stats:
+    x-audience: Internal
     get:
-      operationId: statsManufacturerV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: A ISO 8601 timestamp which marks the end of a 48h time range
-          in which the data is collected
-        explode: true
-        in: query
-        name: session
-        required: true
-        schema:
-          format: date-time
-          type: string
-        style: form
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ContractStats'
-          description: 'Get the contract statistics: product count, vendor count,
-            found offers count (filters applied), active portals count, found offers
-            count (no filters applied)'
+          description: 'Get the contract statistics: product count, vendor count, found offers count (filters applied), active portals count, found offers count (no filters applied)'
       tags:
-      - internal
-      - offers
-  /api/2/m/contracts/{contractId}/result/offersegmentation:
-    post:
-      operationId: segmentOffersManufacturerV2
+        - internal
+        - offers
+      operationId: statsManufacturerV2
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: This is a generated entry and needs to be described.
+        - in: query
+          name: session
+          required: true
+          schema:
+            type: string
+            format: date-time
+          description: A ISO 8601 timestamp which marks the end of a 48h time range in which the data is collected
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/2/m/contracts/{contractId}/result/offersegmentation:
+    x-audience: Internal
+    post:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - offers
+        - internal
+        - undocumented
+        - offers
+      operationId: segmentOffersManufacturerV2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/m/contracts/{contractId}/result/pricecutters:
+    x-audience: Internal
     post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - offers
       operationId: getPriceCuttersManufacturerV2
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: session
-        required: true
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: limit
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
-      - explode: true
-        in: query
-        name: includeDeliveryCosts
-        required: true
-        schema:
-          type: boolean
-        style: form
+        - in: query
+          name: session
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: includeDeliveryCosts
+          required: true
+          schema:
+            type: boolean
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/2/m/contracts/{contractId}/result/pricesbyday/productid/{productId}:
+    x-audience: Internal
+    post:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                type: object
-          description: This is a generated entry and needs to be described.
+                type: array
+                items:
+                  $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PricesByDayByProductIdResponseV2'
+          description: The list of all known prices for the queried day & product ID
       tags:
-      - internal
-      - undocumented
-      - offers
-  /api/2/m/contracts/{contractId}/result/pricesbyday/productid/{productId}:
-    post:
+        - internal
+        - offers
       operationId: pricesByDayByProductIdManufacturerV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: The product ID to filter for
-        explode: false
-        in: path
-        name: productId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PricesByDayByProductIdRequestV2'
-        description: Query all known prices for a given day & product ID. Can be filtered
-          by using the selectors.
+        description: Query all known prices for a given day & product ID. Can be filtered by using the selectors.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
+        name: productId
+        required: true
+        schema:
+          type: string
+        description: The product ID to filter for
+  /api/2/m/contracts/{contractId}/result/priceviolations:
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PricesByDayByProductIdResponseV2'
-                type: array
-          description: The list of all known prices for the queried day & product
-            ID
+                type: object
+          description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - offers
-  /api/2/m/contracts/{contractId}/result/priceviolations:
-    get:
+        - internal
+        - undocumented
+        - offers
       operationId: getProductPriceViolationsManufacturerV2
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: start
-        required: true
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: end
-        required: true
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: includeDeliveryCosts
-        required: true
-        schema:
-          type: boolean
-        style: form
-      - explode: true
-        in: query
-        name: referencePriceDelta
-        required: true
-        schema:
-          format: double
-          type: number
-        style: form
+        - in: query
+          name: start
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: end
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: includeDeliveryCosts
+          required: true
+          schema:
+            type: boolean
+        - in: query
+          name: referencePriceDelta
+          required: true
+          schema:
+            type: number
+            format: double
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/2/m/contracts/{contractId}/result/timestamps:
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - offers
-  /api/2/m/contracts/{contractId}/result/timestamps:
-    get:
+        - internal
+        - undocumented
+        - offers
       operationId: timestampsManufacturerV2
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: limit
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: integer
+            format: int32
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/2/m/contracts/{contractId}/result/validation:
+    x-audience: Internal
+    post:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - offers
-  /api/2/m/contracts/{contractId}/result/validation:
-    post:
+        - internal
+        - undocumented
+        - offers
       operationId: validateOffersManufacturerV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/2/m/contracts/{contractId}/result/vendors/cheapest:
+    x-audience: Internal
+    post:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - offers
-  /api/2/m/contracts/{contractId}/result/vendors/cheapest:
-    post:
+        - internal
+        - undocumented
+        - offers
       operationId: getCheapestVendorsManufacturerV2
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: session
-        required: true
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: includeDeliveryCosts
-        required: true
-        schema:
-          type: boolean
-        style: form
+        - in: query
+          name: session
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: includeDeliveryCosts
+          required: true
+          schema:
+            type: boolean
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.TagFilteredVendorsRequest'
         description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - offers
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/m/contracts/{contractId}/result/vendors/list:
+    x-audience: Internal
     post:
-      operationId: getVendorsByDomainManufacturerV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: domain
-        required: true
-        schema:
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: start
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
-      - explode: true
-        in: query
-        name: includeDeliveryCosts
-        required: true
-        schema:
-          type: boolean
-        style: form
-      - explode: true
-        in: query
-        name: session
-        required: true
-        schema:
-          format: date-time
-          type: string
-        style: form
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.TagFilteredVendorsRequest'
-        description: This is a generated entry and needs to be described.
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostVendorsByDomainResponse'
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - offers
-  /api/2/m/contracts/{contractId}/settings/imagetag:
-    put:
-      operationId: putImageTagManufacturerV2
+        - internal
+        - undocumented
+        - offers
+      operationId: getVendorsByDomainManufacturerV2
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - in: query
+          name: domain
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: start
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: includeDeliveryCosts
+          required: true
+          schema:
+            type: boolean
+        - in: query
+          name: session
+          required: true
+          schema:
+            type: string
+            format: date-time
       requestBody:
         content:
           application/json:
             schema:
-              type: object
+              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.TagFilteredVendorsRequest'
         description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/2/m/contracts/{contractId}/settings/imagetag:
+    x-audience: Internal
+    put:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
+        - internal
+        - undocumented
+        - settings
+      operationId: putImageTagManufacturerV2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/m/contracts/{contractId}/settings/monitoring:
+    x-audience: Internal
     get:
       description: Get the current monitoring settings for a given contract
-      operationId: getMonitoringSettingsManufacturerV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: The current monitoring settings object
       tags:
-      - internal
-      - settings
+        - internal
+        - settings
+      operationId: getMonitoringSettingsManufacturerV2
     put:
       description: Update the monitoring settings for a given contract
-      operationId: putMonitoringSettingsManufacturerV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: The monitoring settings object to be written to the database
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: Returns the successfully updated monitoring settings object
       tags:
-      - internal
-      - settings
-  /api/2/m/contracts/{contractId}/tasks:
-    get:
-      description: Returns a list of task objects for the given contract
-      operationId: getTasksManufacturerV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Comma separated list of task IDs to filter for
-        explode: true
-        in: query
-        name: taskIdsFilter
-        required: false
-        schema:
-          type: string
-        style: form
-      - description: A list of task types to filter for
-        explode: true
-        in: query
-        name: taskTypeFilter
-        required: true
-        schema:
-          items:
-            type: string
-          type: array
-        style: form
-      - description: A list of task states to filter for
-        explode: true
-        in: query
-        name: taskState
-        required: true
-        schema:
-          items:
-            enum:
-            - pending
-            - executing
-            - succeeded
-            - failed
-            type: string
-          type: array
-        style: form
-      - description: Ignore all tasks created earlier than this date (ISO 8601)
-        explode: true
-        in: query
-        name: minCreationDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - description: Ignore all tasks created later than this date (ISO 8601)
-        explode: true
-        in: query
-        name: maxCreationDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - description: The maximum number of tasks returned
-        explode: true
-        in: query
-        name: limit
-        required: true
-        schema:
-          default: 100
-          format: int32
-          type: integer
-        style: form
-      - description: Include failed tasks
-        explode: true
-        in: query
-        name: includeFailures
-        required: true
-        schema:
-          default: true
-          type: boolean
-        style: form
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                items:
-                  $ref: '#/components/schemas/GenericTask'
-                type: array
-          description: The list of tasks for the given contract
-      tags:
-      - internal
-      - tasks
-    post:
-      description: Create a new task
-      operationId: createTaskManufacturerV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - internal
+        - settings
+      operationId: putMonitoringSettingsManufacturerV2
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CreateTaskBodyV2'
-        description: This is a generated entry and needs to be described.
+              type: object
+        description: The monitoring settings object to be written to the database
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/2/m/contracts/{contractId}/tasks:
+    x-audience: Internal
+    get:
+      description: Returns a list of task objects for the given contract
       responses:
-        "200":
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GenericTask'
+          description: The list of tasks for the given contract
+      tags:
+        - internal
+        - tasks
+      operationId: getTasksManufacturerV2
+      parameters:
+        - in: query
+          name: taskIdsFilter
+          required: false
+          schema:
+            type: string
+          description: Comma separated list of task IDs to filter for
+        - in: query
+          name: taskTypeFilter
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+          description: A list of task types to filter for
+        - in: query
+          name: taskState
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - pending
+                - executing
+                - succeeded
+                - failed
+          description: A list of task states to filter for
+        - in: query
+          name: minCreationDate
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Ignore all tasks created earlier than this date (ISO 8601)
+        - in: query
+          name: maxCreationDate
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Ignore all tasks created later than this date (ISO 8601)
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: integer
+            format: int32
+            default: 100
+          description: The maximum number of tasks returned
+        - in: query
+          name: includeFailures
+          required: true
+          schema:
+            type: boolean
+            default: true
+          description: Include failed tasks
+    post:
+      x-audience: Internal
+      description: Create a new task
+      responses:
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericTaskWithUrl'
           description: The new task was successfully created
       tags:
-      - internal
-      - tasks
+        - internal
+        - tasks
+      operationId: createTaskManufacturerV2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CreateTaskBodyV2'
+        description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/m/contracts/{contractId}/tasks/{taskId}:
+    x-audience: Internal
     get:
-      description: Get the task designated by the taskId parameter
-      operationId: getTaskManufacturerV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
-        name: taskId
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericTask'
           description: The task was found and is returned
-        "404":
+        '404':
           description: No task with given taskId was found
       tags:
-      - internal
-      - tasks
+        - internal
+        - tasks
+      operationId: getTaskManufacturerV2
+      description: Get the task designated by the taskId parameter
     put:
       description: Update an existing task
-      operationId: updateTaskManufacturerV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
-        name: taskId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdateTaskRequestV2'
-        description: The new task object to be written to the database
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericTask'
           description: The task was successfully updated and the given data is returned
       tags:
-      - internal
-  /api/2/m/contracts/{contractId}/tasks/{taskId}/data:
-    description: Returns the payload data given during creation of the requested task
-    get:
-      operationId: getTaskDataManufacturerV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
+        - internal
+      operationId: updateTaskManufacturerV2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateTaskRequestV2'
+        description: The new task object to be written to the database
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
         name: taskId
         required: true
         schema:
           type: string
-        style: simple
+  /api/2/m/contracts/{contractId}/tasks/{taskId}/data:
+    x-audience: Internal
+    description: Returns the payload data given during creation of the requested task
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: The payload data of the requested task is returned
-        "404":
+        '404':
           description: The task with the given ID could not be found
       tags:
-      - internal
-      - tasks
-  /api/2/users/{userId}/role/{roleName}:
-    delete:
-      operationId: deleteUserRole
-      parameters:
-      - explode: false
-        in: path
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
-        style: simple
-      - explode: false
-        in: path
-        name: roleName
+        - internal
+        - tasks
+      operationId: getTaskDataManufacturerV2
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
+        name: taskId
         required: true
         schema:
           type: string
-        style: simple
+  /api/2/users/{userId}/role/{roleName}:
+    x-audience: Internal
+    delete:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - account
+        - internal
+        - undocumented
+        - account
+      operationId: deleteUserRole
     put:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - account
       operationId: updateUserRole
-      parameters:
-      - explode: false
-        in: path
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
-        style: simple
-      - explode: false
-        in: path
-        name: roleName
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
+    parameters:
+      - in: path
+        name: userId
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - in: path
+        name: roleName
+        required: true
+        schema:
+          type: string
+  /api/2/v/contracts:
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - account
-  /api/2/v/contracts:
-    get:
+        - internal
+        - undocumented
+        - companies
       operationId: getContractsVendorV2
       parameters:
-      - explode: true
-        in: query
-        name: maxCreationDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: minExpirationDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - companies
+        - in: query
+          name: maxCreationDate
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: minExpirationDate
+          required: false
+          schema:
+            type: string
+            format: date-time
   /api/2/v/contracts/{contractId}:
-    delete:
-      operationId: deleteContractVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - companies
-    get:
+        - internal
+        - undocumented
+        - companies
       operationId: getVendorVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+    delete:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - companies
+        - internal
+        - undocumented
+        - companies
+      operationId: deleteContractVendorV2
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/feeds/{feedId}/export:
+    x-audience: Internal
     get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - feeds
       operationId: getFeedExportVendorV2
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
+        - in: query
+          name: fileName
+          required: false
+          schema:
+            type: string
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
         name: feedId
         required: true
         schema:
           type: string
-        style: simple
-      - explode: true
-        in: query
-        name: fileName
-        required: false
-        schema:
-          type: string
-        style: form
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - feeds
   /api/2/v/contracts/{contractId}/offerfilters/{listType}/complex:
+    x-audience: Internal
     get:
-      operationId: getComplexOfferFiltersVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
-        name: listType
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/OfferFilterApiResponse'
           description: List of the filters to ignore the individual offers.
-      summary: Get all complex filters for the given contract.
       tags:
-      - internal
-      - offers
+        - internal
+        - offers
+      operationId: getComplexOfferFiltersVendorV2
+      summary: Get all complex filters for the given contract.
     put:
-      operationId: putComplexOfferFiltersVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
-        name: listType
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/OfferFilterRequest'
-        description: List of the filter that needs to be considered to ignore the
-          individual offers.
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/OfferFilterApiResponse'
           description: List of the filters that have been sent as the request body.
-      summary: Add the complex filters for the given contract.
       tags:
-      - internal
-      - offers
-  /api/2/v/contracts/{contractId}/offerfilters/{listType}/products:
-    get:
-      operationId: getProductFiltersByRangeVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
+        - internal
+        - offers
+      operationId: putComplexOfferFiltersVendorV2
+      summary: Add the complex filters for the given contract.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OfferFilterRequest'
+        description: List of the filter that needs to be considered to ignore the individual offers.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
         name: listType
         required: true
         schema:
           type: string
-        style: simple
-      - explode: true
-        in: query
-        name: start
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
-      - explode: true
-        in: query
-        name: limit
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
+  /api/2/v/contracts/{contractId}/offerfilters/{listType}/products:
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: List of the filters per product to ignore the individual offers.
-      summary: Get all the filters product-wise for the given contract.
       tags:
-      - internal
-      - offers
-  /api/2/v/contracts/{contractId}/offerfilters/{listType}/products/{productId}:
-    get:
-      operationId: getProductFiltersVendorV2
+        - internal
+        - offers
+      operationId: getProductFiltersByRangeVendorV2
+      summary: Get all the filters product-wise for the given contract.
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
+        - in: query
+          name: start
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: integer
+            format: int32
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
         name: listType
         required: true
         schema:
           type: string
-        style: simple
-      - explode: false
-        in: path
-        name: productId
-        required: true
-        schema:
-          type: string
-        style: simple
+  /api/2/v/contracts/{contractId}/offerfilters/{listType}/products/{productId}:
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/OfferFilterApiResponse'
           description: List of the filters to ignore the individual offers.
-      summary: Get all the filters of a given product for the given contract.
       tags:
-      - internal
-      - products
+        - internal
+        - products
+      operationId: getProductFiltersVendorV2
+      summary: Get all the filters of a given product for the given contract.
     put:
-      operationId: putProductFiltersVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
-        name: listType
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
-        name: productId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/OfferFilterRequest'
-        description: List of the filter that needs to be considered to ignore the
-          individual offers.
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/OfferFilterApiResponse'
           description: List of the filters that have been sent as the request body.
-      summary: Store the filters of a given product for the given contract.
       tags:
-      - internal
-      - products
-  /api/2/v/contracts/{contractId}/offerfilters/:listType/products/query:
-    post:
-      operationId: getProductFiltersByIDVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - internal
+        - products
+      operationId: putProductFiltersVendorV2
+      summary: Store the filters of a given product for the given contract.
       requestBody:
         content:
           application/json:
             schema:
-              type: object
-        description: This is a generated entry and needs to be described.
+              $ref: '#/components/schemas/OfferFilterRequest'
+        description: List of the filter that needs to be considered to ignore the individual offers.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
+        name: listType
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: productId
+        required: true
+        schema:
+          type: string
+  /api/2/v/contracts/{contractId}/offerfilters/:listType/products/query:
+    x-audience: Internal
+    post:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - offers
-  /api/2/v/contracts/{contractId}/offerfilters/{listType}/vendors:
-    get:
-      operationId: getOfferFiltersVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
-        name: listType
-        required: true
-        schema:
-          type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: List of the filters to ignore the individual offers. Offers
-            are filtered against vendor name either for all the domain or for a specific
-            domain.
-      summary: Get all the vendor filters for the given contract.
-      tags:
-      - internal
-      - offers
-    put:
-      operationId: putOfferFiltersVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
-        name: listType
-        required: true
-        schema:
-          type: string
-        style: simple
+        - internal
+        - undocumented
+        - offers
+      operationId: getProductFiltersByIDVendorV2
       requestBody:
         content:
           application/json:
             schema:
               type: object
-        description: List of the filters that needs to be considered to ignore the
-          individual offers.
+        description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/2/v/contracts/{contractId}/offerfilters/{listType}/vendors:
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: List of the filters to ignore the individual offers. Offers are filtered against vendor name either for all the domain or for a specific domain.
+      tags:
+        - internal
+        - offers
+      operationId: getOfferFiltersVendorV2
+      summary: Get all the vendor filters for the given contract.
+    put:
+      responses:
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: List of the filters that have been sent as the request body.
-      summary: Store the vendor filters for the given contract.
       tags:
-      - internal
-      - offers
+        - internal
+        - offers
+      operationId: putOfferFiltersVendorV2
+      summary: Store the vendor filters for the given contract.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: List of the filters that needs to be considered to ignore the individual offers.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
+        name: listType
+        required: true
+        schema:
+          type: string
   /api/2/v/contracts/{contractId}/offers:
     post:
+      responses:
+        '200':
+          description: |
+            The server understood and processed the request. Offers were processed, but not necessarily stored successfully. The 'data' field in the response body contains a detailed report of the operation outcome for each individual POST offers requests. Each item in the 'data' array is **either** a 'data' object with value true (indicating successful storage), or an ApiErrorResponse (indicating a storage failure).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostOffersResponse'
+        '400':
+          description: |
+            The server could not understand the request due to invalid syntax. For example, a required field might be missing in the request body.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - offers
+      operationId: postOffersInABulkVendorV2
+      summary: Add offers in bulk
       description: |
         This endpoint can be used to provide external offers to Pricemonitor. It's a bulk endpoint which accepts an array of individual POST offers requests each based on a "snapshot" - a unique combination of product, domain, and timestamp for a list of offers.
         Please note the following consistency checks performed before offers are stored:
@@ -4959,314 +3778,203 @@ paths:
         4. Duplicated individual POST offers requests are stored only once.
         5. If different offers are provided for the same snapshots, then all conflicting snapshots will be rejected.
         6. An individual POST offers request may be rejected if the offer ID is not unique.
-      operationId: postOffersInABulkVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
+              type: array
               items:
                 $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostProductOfferRequest'
-              type: array
-        description: List of individual POST offers requests which should be added
-          in bulk.
+        description: List of individual POST offers requests which should be added in bulk.
         required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostOffersResponse'
-          description: |
-            The server understood and processed the request. Offers were processed, but not necessarily stored successfully. The 'data' field in the response body contains a detailed report of the operation outcome for each individual POST offers requests. Each item in the 'data' array is **either** a 'data' object with value true (indicating successful storage), or an ApiErrorResponse (indicating a storage failure).
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: |
-            The server could not understand the request due to invalid syntax. For example, a required field might be missing in the request body.
-      summary: Add offers in bulk
-      tags:
-      - offers
+      parameters:
+        - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/productidentifiermapping:
+    x-audience: Internal
+    post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - products
+      operationId: postMappingsVendorV2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
     get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - products
       operationId: getMappingsVendorV2
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: inputType
-        required: true
-        schema:
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: identifiers
-        required: true
-        schema:
-          items:
+        - in: query
+          name: inputType
+          required: true
+          schema:
             type: string
-          type: array
-        style: form
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - products
-    post:
-      operationId: postMappingsVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - products
+        - in: query
+          name: identifiers
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/products/import:
+    x-audience: Internal
     post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - products
       operationId: shopIntegrationPostRequestVendorV2
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: path
-        required: true
-        schema:
-          type: string
-        style: form
+        - in: query
+          name: path
+          required: true
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - products
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/products/tags:
+    x-audience: Internal
     get:
-      operationId: getTagsVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - products
+        - internal
+        - undocumented
+        - products
+      operationId: getTagsVendorV2
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/products/tags/{key}:
+    x-audience: Internal
     get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - products
       operationId: getTagValuesVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
         name: key
         required: true
         schema:
           type: string
-        style: simple
+  /api/2/v/contracts/{contractId}/result/offersegmentation:
+    x-audience: Internal
+    post:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - products
-  /api/2/v/contracts/{contractId}/result/offersegmentation:
-    post:
+        - internal
+        - undocumented
+        - offers
       operationId: segmentOffersVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/2/v/contracts/{contractId}/result/pricecutters:
+    x-audience: Internal
+    post:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - offers
-  /api/2/v/contracts/{contractId}/result/pricecutters:
-    post:
+        - internal
+        - undocumented
+        - offers
       operationId: getPriceCuttersVendorV2
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: session
-        required: true
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: limit
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
-      - explode: true
-        in: query
-        name: includeDeliveryCosts
-        required: true
-        schema:
-          type: boolean
-        style: form
+        - in: query
+          name: session
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: includeDeliveryCosts
+          required: true
+          schema:
+            type: boolean
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - offers
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/result/pricerecommendations/query:
-    description: |
-      This endpoint is used to query certain price recommendations. <br>
-      Warning: This endpoint contains complex query structure and will be replaced in the future.
+    x-audience: Internal
     post:
-      operationId: queryPriceRecommendationsVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PriceRecommendationApiQueryV2'
-        description: The request body specifies which price recommendations will be
-          searched for.
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
@@ -5275,1565 +3983,792 @@ paths:
             A paginated list of price recommendations is returned for the specified timerange. <br>
             Only the newest price recommendations are returned in case of multiple price recommendations per product.
       tags:
-      - internal
-      - pricerecommendations
+        - internal
+        - pricerecommendations
+      operationId: queryPriceRecommendationsVendorV2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PriceRecommendationApiQueryV2'
+        description: The request body specifies which price recommendations will be searched for.
+    description: |
+      This endpoint is used to query certain price recommendations. <br>
+      Warning: This endpoint contains complex query structure and will be replaced in the future.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/result/pricerecommendationstats:
+    x-audience: Internal
     get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - pricerecommendations
       operationId: getPriceRecommendationStatsVendorV2
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: startTime
-        required: true
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: endTime
-        required: true
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: maxPositions
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
+        - in: query
+          name: startTime
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: endTime
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: maxPositions
+          required: true
+          schema:
+            type: integer
+            format: int32
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/2/v/contracts/{contractId}/result/priceviolations:
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - pricerecommendations
-  /api/2/v/contracts/{contractId}/result/priceviolations:
-    get:
+        - internal
+        - undocumented
+        - offers
       operationId: getProductPriceViolationsVendorV2
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: start
-        required: true
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: end
-        required: true
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: includeDeliveryCosts
-        required: true
-        schema:
-          type: boolean
-        style: form
-      - explode: true
-        in: query
-        name: referencePriceDelta
-        required: true
-        schema:
-          format: double
-          type: number
-        style: form
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - offers
+        - in: query
+          name: start
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: end
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: includeDeliveryCosts
+          required: true
+          schema:
+            type: boolean
+        - in: query
+          name: referencePriceDelta
+          required: true
+          schema:
+            type: number
+            format: double
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/result/validation:
+    x-audience: Internal
     post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - offers
       operationId: validateOffersVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - offers
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/settings/callbacks:
-    delete:
-      operationId: deleteCallbackSettingsVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
-    get:
+        - internal
+        - undocumented
+        - settings
       operationId: getCallbacksVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+    put:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
-    put:
+        - internal
+        - undocumented
+        - settings
       operationId: putCallbacksVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
+    delete:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
+        - internal
+        - undocumented
+        - settings
+      operationId: deleteCallbackSettingsVendorV2
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/settings/currency:
+    x-audience: Internal
     get:
-      operationId: getCurrencyVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
+        - internal
+        - undocumented
+        - settings
+      operationId: getCurrencyVendorV2
     put:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - settings
       operationId: putCurrencyVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/2/v/contracts/{contractId}/settings/ebay/authorizations:
+    x-audience: Internal
+    post:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
-  /api/2/v/contracts/{contractId}/settings/ebay/authorizations:
+        - internal
+        - undocumented
+        - settings
+      operationId: postEbayAuthorizationVendorV2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
     get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - settings
       operationId: getAllEbayAuthorizationsVendorV2
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: start
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
-      - explode: true
-        in: query
-        name: limit
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
-    post:
-      operationId: postEbayAuthorizationVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
+        - in: query
+          name: start
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: integer
+            format: int32
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/settings/ebay/authorizations/{authIds}:
+    x-audience: Internal
     get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - settings
       operationId: getEbayAuthorizationsVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
         name: authIds
         required: true
         schema:
           type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
   /api/2/v/contracts/{contractId}/settings/ebay/token:
+    x-audience: Internal
     get:
-      operationId: getActiveEbayTokenVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
+        - internal
+        - undocumented
+        - settings
+      operationId: getActiveEbayTokenVendorV2
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/settings/ebay/tokens:
+    x-audience: Internal
     get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - settings
       operationId: getAllEbayTokensVendorV2
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: start
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
-      - explode: true
-        in: query
-        name: limit
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
+        - in: query
+          name: start
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: integer
+            format: int32
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/settings/imagetag:
+    x-audience: Internal
     put:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - settings
       operationId: putImageTagVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/2/v/contracts/{contractId}/settings/import:
-    delete:
-      operationId: deleteImportSettingsVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
-    get:
+        - internal
+        - undocumented
+        - settings
       operationId: getImportSettingsVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+    put:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
-    put:
+        - internal
+        - undocumented
+        - settings
       operationId: putImportSettingsVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
-  /api/2/v/contracts/{contractId}/settings/monitoring:
-    get:
-      operationId: getMonitoringSettingsVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
-    put:
-      operationId: putMonitoringSettingsVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
-  /api/2/v/contracts/{contractId}/settings/repricing:
-    get:
-      operationId: getVendorSettings_V2VendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
-    put:
-      operationId: putVendorSettingsVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
-  /api/2/v/contracts/{contractId}/settings/repricingstrategy:
     delete:
-      operationId: deleteRepricingStrategyVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
-          description: Delete all strategy versions per provided contract
+          description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - pricerecommendations
+        - internal
+        - undocumented
+        - settings
+      operationId: deleteImportSettingsVendorV2
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/2/v/contracts/{contractId}/settings/monitoring:
+    x-audience: Internal
     get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - settings
+      operationId: getMonitoringSettingsVendorV2
+    put:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - settings
+      operationId: putMonitoringSettingsVendorV2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/2/v/contracts/{contractId}/settings/repricing:
+    x-audience: Internal
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - settings
+      operationId: getVendorSettings_V2VendorV2
+    put:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - settings
+      operationId: putVendorSettingsVendorV2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/2/v/contracts/{contractId}/settings/repricingstrategy:
+    x-audience: Internal
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: In case a document version is provided, get that strategy version. Otherwise get latest strategy for this contract.
+      tags:
+        - internal
+        - undocumented
+        - pricerecommendations
       operationId: getRepricingStrategyVendorV2
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - example: 5
-        explode: true
-        in: query
-        name: documentVersion
-        required: false
-        schema:
-          format: int32
-          minimum: 1
-          type: integer
-        style: form
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: In case a document version is provided, get that strategy version.
-            Otherwise get latest strategy for this contract.
-      tags:
-      - internal
-      - undocumented
-      - pricerecommendations
+        - in: query
+          name: documentVersion
+          required: false
+          example: 5
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
     put:
-      operationId: putRepricingStrategyVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: This is a generated entry and needs to be described.
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: Save a new strategy version
       tags:
-      - internal
-      - undocumented
-      - pricerecommendations
-  /api/2/v/contracts/{contractId}/tasks/{taskId}/data:
-    get:
-      operationId: getTaskDataVendorV2
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
-        name: taskId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - internal
+        - undocumented
+        - pricerecommendations
+      operationId: putRepricingStrategyVendorV2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
+    delete:
       responses:
-        "200":
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Delete all strategy versions per provided contract
+      tags:
+        - internal
+        - undocumented
+        - pricerecommendations
+      operationId: deleteRepricingStrategyVendorV2
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/2/v/contracts/{contractId}/tasks/{taskId}/data:
+    x-audience: Internal
+    get:
+      responses:
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - tasks
+        - internal
+        - undocumented
+        - tasks
+      operationId: getTaskDataVendorV2
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
+        name: taskId
+        required: true
+        schema:
+          type: string
   /api/account/password/reset:
+    x-audience: Internal
     post:
+      responses:
+        '200':
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Eine E-Mail mit Anweisungen zum Zurücksetzen des Passworts wurde versandt. Bitte überprüfen Sie Ihren Spam-Ordner und ggf. die angegebene E-Mail-Adresse, falls in den nächsten Minuten keine E-Mail ankommen sollte.
+          description: Successful response upon password request
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Invalid request body is specified
+      tags:
+        - internal
+        - account
       operationId: requestNewPassword
+      summary: Request a new password
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostNewPasswordRequest'
         description: Request a new password.
+    put:
       responses:
-        "200":
+        '200':
           content:
             text/plain:
               schema:
-                example: Eine E-Mail mit Anweisungen zum Zurücksetzen des Passworts
-                  wurde versandt. Bitte überprüfen Sie Ihren Spam-Ordner und ggf.
-                  die angegebene E-Mail-Adresse, falls in den nächsten Minuten keine
-                  E-Mail ankommen sollte.
                 type: string
-          description: Successful response upon password request
-        "400":
+                example: Das Passwort wurde erfolgreich geändert.
+          description: Password changed successfully.
+        '400':
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: Invalid request body is specified
-      summary: Request a new password
+                type: string
+                example: Der benutzte Link ist abgelaufen, bitte benutzen Sie die Passwort-Vergessen Funktion erneut.
+          description: Password didn't change successfully.
       tags:
-      - internal
-      - account
-    put:
+        - internal
+        - account
       operationId: resetPassword
+      summary: Reset the password
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PutResetPasswordRequest'
         description: Reset a password
-      responses:
-        "200":
-          content:
-            text/plain:
-              schema:
-                example: Das Passwort wurde erfolgreich geändert.
-                type: string
-          description: Password changed successfully.
-        "400":
-          content:
-            text/plain:
-              schema:
-                example: Der benutzte Link ist abgelaufen, bitte benutzen Sie die
-                  Passwort-Vergessen Funktion erneut.
-                type: string
-          description: Password didn't change successfully.
-      summary: Reset the password
-      tags:
-      - internal
-      - account
   /api/login/token/{token}:
+    x-audience: Internal
     get:
-      operationId: loginByAuthToken
-      parameters:
-      - explode: false
-        in: path
-        name: token
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
-      security: []
       tags:
-      - internal
-      - undocumented
-      - account
-  /api/v3/manufacturer/contracts/{contractId}:
-    get:
-      operationId: getManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
+        - internal
+        - undocumented
+        - account
+      operationId: loginByAuthToken
+      security: []
+    parameters:
+      - in: path
+        name: token
         required: true
         schema:
           type: string
-        style: simple
+  /api/v3/manufacturer/contracts/{contractId}:
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetManufacturerV3ApiResponse'
           description: Contract Information
+      tags:
+        - internal
+        - companies
+      operationId: getManufacturerV3
       summary: Get the contract information
-      tags:
-      - internal
-      - companies
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/v3/manufacturer/contracts/{contractId}/monitoringpipeline/v1/searchattempts:
+    x-audience: Internal
     post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - products
       operationId: monitoringPipelineUpsertSearchAttemptsManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - products
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/v3/manufacturer/contracts/{contractId}/offers/query:
+    x-audience: Internal
     post:
-      operationId: queryOffersManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: This is a generated entry and needs to be described.
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - offers
+        - internal
+        - undocumented
+        - offers
+      operationId: queryOffersManufacturerV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /api/v3/manufacturer/contracts/{contractId}/offers/pricedumpingstats:
     post:
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - $ref: '#/components/parameters/contractIdParam'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryPriceDumpingStatsApiResponse'
+          description: Returns the price dumping statistics in the given time range.
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PriceDumpingStatsRequest'
         required: true
+      tags:
+        - products
+  /api/v3/manufacturer/contracts/{contractId}/products/{productId}:
+    x-audience: Internal
+    patch:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/QueryPriceDumpingStatsApiResponse'
-          description: Returns the price dumping statistics in the given time range.
+                type: object
+          description: This is a generated entry and needs to be described.
       tags:
-      - products
-  /api/v3/manufacturer/contracts/{contractId}/products/{productId}:
-    patch:
+        - internal
+        - undocumented
+        - products
       operationId: patchProductManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
-        name: productId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - products
-  /api/v3/manufacturer/contracts/{contractId}/products/{productId}/extendedtags:
-    get:
-      operationId: getExtendedTagsManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
         name: productId
         required: true
         schema:
           type: string
-        style: simple
+  /api/v3/manufacturer/contracts/{contractId}/products/{productId}/extendedtags:
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - products
-  /api/v3/manufacturer/contracts/{contractId}/products/query:
-    description: This endpoint can be used for querying either all products or certain
-      products by product ids.
-    post:
-      operationId: queryProductsByFilterManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
+        - internal
+        - undocumented
+        - products
+      operationId: getExtendedTagsManufacturerV3
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
+        name: productId
         required: true
         schema:
           type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/QueryProductsRequestV3'
-        description: The body contains the products query.
+  /api/v3/manufacturer/contracts/{contractId}/products/query:
+    x-audience: Internal
+    post:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/QueryProductsByFilterManufacturerV3ApiResponse'
           description: Returns a list of found products.
       tags:
-      - internal
-      - products
-    summary: Get products of a contract
-  /api/v3.1/manufacturer/contracts/{contractId}/products/query:
-    description: This endpoint can be used for querying either all products or certain
-      products by the 'customerProductId' or 'productId'.
-    post:
-      operationId: queryProductsManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiQuery'
-        description: |
-          The body contains the products query. <br>
-          Currently, it supports only product queries for two attributes:<br>
-          <ul>
-            <li> by "customerProductId"</li>
-            <li> by "productId" (Patagona's internal product id). Allowed values for 'productId' are numerical integer values</li>
-          </ul>
-          The maximum allowed limit in the pagination is 10000. <br>
-          For better performance, when paginating over all products of a contract, we recommend to use a limit of 10000 products per page.
-          Pagination works with respective to the given products query. <br>
-          This is most relevant when querying for a set of customerProductId's. <br>
-          When the requests are chunked over a set of ids, it is easiest to provide up to 10000 customerProductId's in the query and keep the pagination at start: 0, limit: 10000. <br>
-          The only allowed pattern is currently: <br>
-          { <br>
-          &nbsp;&nbsp;"pagination": { <br>
-          &nbsp;&nbsp;&nbsp;&nbsp;"start": ${start}, <br>
-          &nbsp;&nbsp;&nbsp;&nbsp;"limit": ${limit} <br>
-          &nbsp;&nbsp;}, <br>
-          &nbsp;&nbsp;"filter": { <br>
-          &nbsp;&nbsp;&nbsp;&nbsp;"oneOf": { <br>
-          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"field": "customerProductId", <br>
-          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"values": [${customerProductIds as a list of strings}] <br>
-          &nbsp;&nbsp;&nbsp;&nbsp;} <br>
-          &nbsp;&nbsp;} <br>
-          } <br>
-          <br>
-          example: <br>
-          { <br>
-          &nbsp;&nbsp;"pagination": { <br>
-          &nbsp;&nbsp;&nbsp;&nbsp;"start": 0, <br>
-          &nbsp;&nbsp;&nbsp;&nbsp;"limit": 10 <br>
-          &nbsp;&nbsp;}, <br>
-          &nbsp;&nbsp;"filter": { <br>
-          &nbsp;&nbsp;"oneOf": { <br>
-          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"field": "customerProductId", <br>
-          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"values": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] <br>
-          &nbsp;&nbsp;&nbsp;&nbsp;} <br>
-          &nbsp;&nbsp;} <br>
-          } <br>
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/QueryProductsManufacturerV3ApiResponse'
-          description: Returns a list of found products.
-      tags:
-      - products
-    summary: Get products of a contract
-  /api/v3/manufacturer/contracts/{contractId}/settings/customer:
-    get:
-      operationId: getCustomerContractSettingsManufaturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetCustomerContractSettingsApiResponse'
-          description: Settings for this contract.
-      tags:
-      - internal
-      - undocumented
-      - settings
-    put:
-      operationId: putCustomerContractSettingsManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CustomerContractSettings'
-        description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PutCustomerContractSettingsApiResponse'
-          description: Settings for this contract.
-      tags:
-      - internal
-      - undocumented
-      - settings
-  /api/v3/manufacturer/contracts/{contractId}/settings/monitoring:
-    get:
-      operationId: getMonitoringSettingsManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
-    put:
-      operationId: putMonitoringSettingsManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
-  /api/v3/manufacturer/contracts/{contractId}/settings/offerretention:
-    get:
-      operationId: getOfferRetentionSettingsManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: contractType
-        required: true
-        schema:
-          enum:
-          - Pricemonitor for manufacturers
-          - Pricemonitor for resellers
-          type: string
-        style: form
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
-    put:
-      operationId: putOfferRetentionSettingsManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: contractType
-        required: true
-        schema:
-          enum:
-          - Pricemonitor for manufacturers
-          - Pricemonitor for resellers
-          type: string
-        style: form
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
-  /api/v3/vendor/contracts/{contractId}:
-    get:
-      operationId: getVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - companies
-  /api/v3/vendor/contracts/{contractId}/monitoringpipeline/v1/searchattempts:
-    post:
-      operationId: monitoringPipelineUpsertSearchAttemptsVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - products
-  /api/v3/vendor/contracts/{contractId}/products/{productId}:
-    patch:
-      operationId: patchProductVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
-        name: productId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - products
-  /api/v3/vendor/contracts/{contractId}/products/monitoringstatus:
-    get:
-      operationId: getProductMonitoringStatusVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: The product ids for which the monitoring state should be returned
-        explode: true
-        in: query
-        name: productIds
-        required: true
-        schema:
-          items:
-            type: integer
-          maxItems: 1000
-          minItems: 1
-          type: array
-          uniqueItems: true
-        style: form
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetProductMonitoringStatusVendorV3ApiResponse'
-          description: Monitoring status of the queried products
-      tags:
-      - products
-  /api/v3/vendor/contracts/{contractId}/products/monitoringstatus/stats:
-    get:
-      operationId: getProductMonitoringStatusStatsVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetProductMonitoringStatusStatsVendorV3ApiResponse'
-          description: Contains the monitoring status stats per domain
-      tags:
-      - products
-      - undocumented
-      - internal
-  /api/v3/vendor/contracts/{contractId}/products/query:
-    description: This endpoint can be used for querying either all products or certain
-      products by product ids.
-    post:
-      operationId: queryProductsByFilterVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - internal
+        - products
+      operationId: queryProductsByFilterManufacturerV3
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/QueryProductsRequestV3'
         description: The body contains the products query.
+    summary: Get products of a contract
+    description: This endpoint can be used for querying either all products or certain products by product ids.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/v3.1/manufacturer/contracts/{contractId}/products/query:
+    post:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/QueryProductsByFilterVendorV3ApiResponse'
+                $ref: '#/components/schemas/QueryProductsManufacturerV3ApiResponse'
           description: Returns a list of found products.
       tags:
-      - internal
-      - products
-    summary: Query products of a contract
-  /api/v3/vendor/contracts/{contractId}/products/{productId}/pricerecommendationhistory:
-    description: This endpoint returns all price recommendations for one product within
-      a given time range
-    get:
-      operationId: getProductPriceRecommendationHistory
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: ID of the product in pricemonitor
-        example: 862342
-        explode: false
-        in: path
-        name: productId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Timestamp of start of time range, formatted as ISO Date (i.e.
-          2018-04-06T13:46:13Z) in UTC. If this value is omitted and {endDate} is
-          given, {startDate} is set to {endDate} - 48 hours. If both values are omitted,
-          the range is 'NOW - 48 hours to NOW'.
-        explode: true
-        in: query
-        name: startDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - description: Timestamp of end of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z)
-          in UTC. If this value is omitted and {startDate} is given, {endDate} is
-          set to {startDate} + 48 hours. If both values are omitted, the range is
-          'NOW - 48 hours to NOW'.
-        explode: true
-        in: query
-        name: endDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetPriceRecommendationHistoryApiResponse'
-          description: A list of price recommendations
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: E.g. when the time range spans more than 48h.
-      tags:
-      - products
-    summary: Get price recommendations of one product in time range
-  /api/v3.1/vendor/contracts/{contractId}/products/query:
-    description: This endpoint can be used for querying either all products or certain
-      products by the 'customerProductId' or 'productId'.
-    post:
-      operationId: queryProductsVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - products
+      operationId: queryProductsManufacturerV3
       requestBody:
         content:
           application/json:
@@ -6878,1162 +4813,1183 @@ paths:
           &nbsp;&nbsp;&nbsp;&nbsp;} <br>
           &nbsp;&nbsp;} <br>
           } <br>
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/QueryProductsVendorV3ApiResponse'
-          description: Returns a list of found products.
-      tags:
-      - products
-    summary: Query products of a contract
-  /api/v3/vendor/contracts/{contractId}/settings/customer:
+    summary: Get products of a contract
+    description: This endpoint can be used for querying either all products or certain products by the 'customerProductId' or 'productId'.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/v3/manufacturer/contracts/{contractId}/settings/customer:
+    x-audience: Internal
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
     get:
-      operationId: getCustomerContractSettingsVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetCustomerContractSettingsApiResponse'
           description: Settings for this contract.
       tags:
-      - internal
-      - undocumented
-      - settings
+        - internal
+        - undocumented
+        - settings
+      operationId: getCustomerContractSettingsManufaturerV3
     put:
-      operationId: putCustomerContractSettingsVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CustomerContractSettings'
-        description: This is a generated entry and needs to be described.
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/PutCustomerContractSettingsApiResponse'
           description: Settings for this contract.
       tags:
-      - internal
-      - undocumented
-      - settings
-  /api/v3/vendor/contracts/{contractId}/settings/monitoring:
-    get:
-      operationId: getMonitoringSettingsVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - internal
+        - undocumented
+        - settings
+      operationId: putCustomerContractSettingsManufacturerV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CustomerContractSettings'
+        description: This is a generated entry and needs to be described.
+  /api/v3/manufacturer/contracts/{contractId}/settings/monitoring:
+    x-audience: Internal
+    put:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
-    put:
-      operationId: putMonitoringSettingsVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        - internal
+        - undocumented
+        - settings
+      operationId: putMonitoringSettingsManufacturerV3
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
-  /api/v3/vendor/contracts/{contractId}/settings/offerretention:
+        - internal
+        - undocumented
+        - settings
+      operationId: getMonitoringSettingsManufacturerV3
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/v3/manufacturer/contracts/{contractId}/settings/offerretention:
+    x-audience: Internal
     get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - settings
+      operationId: getOfferRetentionSettingsManufacturerV3
+      parameters:
+        - in: query
+          name: contractType
+          required: true
+          schema:
+            type: string
+            enum:
+              - Pricemonitor for manufacturers
+              - Pricemonitor for resellers
+    put:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - settings
+      operationId: putOfferRetentionSettingsManufacturerV3
+      parameters:
+        - in: query
+          name: contractType
+          required: true
+          schema:
+            type: string
+            enum:
+              - Pricemonitor for manufacturers
+              - Pricemonitor for resellers
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/v3/vendor/contracts/{contractId}:
+    x-audience: Internal
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - companies
+      operationId: getVendorV3
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/v3/vendor/contracts/{contractId}/monitoringpipeline/v1/searchattempts:
+    x-audience: Internal
+    post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - products
+      operationId: monitoringPipelineUpsertSearchAttemptsVendorV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/v3/vendor/contracts/{contractId}/products/{productId}:
+    x-audience: Internal
+    patch:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - products
+      operationId: patchProductVendorV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: path
+        name: productId
+        required: true
+        schema:
+          type: string
+  /api/v3/vendor/contracts/{contractId}/products/monitoringstatus:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetProductMonitoringStatusVendorV3ApiResponse'
+          description: Monitoring status of the queried products
+      tags:
+        - products
+      operationId: getProductMonitoringStatusVendorV3
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - in: query
+        name: productIds
+        schema:
+          type: array
+          items:
+            type: integer
+          minItems: 1
+          uniqueItems: true
+          maxItems: 1000
+        style: form
+        explode: true
+        required: true
+        description: The product ids for which the monitoring state should be returned
+  /api/v3/vendor/contracts/{contractId}/products/monitoringstatus/stats:
+    x-audience: Internal
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetProductMonitoringStatusStatsVendorV3ApiResponse'
+          description: Contains the monitoring status stats per domain
+      tags:
+        - products
+        - undocumented
+        - internal
+      operationId: getProductMonitoringStatusStatsVendorV3
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/v3/vendor/contracts/{contractId}/products/query:
+    x-audience: Internal
+    post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryProductsByFilterVendorV3ApiResponse'
+          description: Returns a list of found products.
+      tags:
+        - internal
+        - products
+      operationId: queryProductsByFilterVendorV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QueryProductsRequestV3'
+        description: The body contains the products query.
+    summary: Query products of a contract
+    description: This endpoint can be used for querying either all products or certain products by product ids.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/v3/vendor/contracts/{contractId}/products/{productId}/pricerecommendationhistory:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPriceRecommendationHistoryApiResponse'
+          description: A list of price recommendations
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: E.g. when the time range spans more than 48h.
+      tags:
+        - products
+      operationId: getProductPriceRecommendationHistory
+    summary: Get price recommendations of one product in time range
+    description: This endpoint returns all price recommendations for one product within a given time range
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - $ref: '#/components/parameters/productIdParam'
+      - $ref: '#/components/parameters/startDate'
+      - $ref: '#/components/parameters/endDate'
+  /api/v3.1/vendor/contracts/{contractId}/products/query:
+    post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryProductsVendorV3ApiResponse'
+          description: Returns a list of found products.
+      tags:
+        - products
+      operationId: queryProductsVendorV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiQuery'
+        description: |
+          The body contains the products query. <br>
+          Currently, it supports only product queries for two attributes:<br>
+          <ul>
+            <li> by "customerProductId"</li>
+            <li> by "productId" (Patagona's internal product id). Allowed values for 'productId' are numerical integer values</li>
+          </ul>
+          The maximum allowed limit in the pagination is 10000. <br>
+          For better performance, when paginating over all products of a contract, we recommend to use a limit of 10000 products per page.
+          Pagination works with respective to the given products query. <br>
+          This is most relevant when querying for a set of customerProductId's. <br>
+          When the requests are chunked over a set of ids, it is easiest to provide up to 10000 customerProductId's in the query and keep the pagination at start: 0, limit: 10000. <br>
+          The only allowed pattern is currently: <br>
+          { <br>
+          &nbsp;&nbsp;"pagination": { <br>
+          &nbsp;&nbsp;&nbsp;&nbsp;"start": ${start}, <br>
+          &nbsp;&nbsp;&nbsp;&nbsp;"limit": ${limit} <br>
+          &nbsp;&nbsp;}, <br>
+          &nbsp;&nbsp;"filter": { <br>
+          &nbsp;&nbsp;&nbsp;&nbsp;"oneOf": { <br>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"field": "customerProductId", <br>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"values": [${customerProductIds as a list of strings}] <br>
+          &nbsp;&nbsp;&nbsp;&nbsp;} <br>
+          &nbsp;&nbsp;} <br>
+          } <br>
+          <br>
+          example: <br>
+          { <br>
+          &nbsp;&nbsp;"pagination": { <br>
+          &nbsp;&nbsp;&nbsp;&nbsp;"start": 0, <br>
+          &nbsp;&nbsp;&nbsp;&nbsp;"limit": 10 <br>
+          &nbsp;&nbsp;}, <br>
+          &nbsp;&nbsp;"filter": { <br>
+          &nbsp;&nbsp;"oneOf": { <br>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"field": "customerProductId", <br>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"values": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] <br>
+          &nbsp;&nbsp;&nbsp;&nbsp;} <br>
+          &nbsp;&nbsp;} <br>
+          } <br>
+    summary: Query products of a contract
+    description: This endpoint can be used for querying either all products or certain products by the 'customerProductId' or 'productId'.
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/v3/vendor/contracts/{contractId}/settings/customer:
+    x-audience: Internal
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetCustomerContractSettingsApiResponse'
+          description: Settings for this contract.
+      tags:
+        - internal
+        - undocumented
+        - settings
+      operationId: getCustomerContractSettingsVendorV3
+    put:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PutCustomerContractSettingsApiResponse'
+          description: Settings for this contract.
+      tags:
+        - internal
+        - undocumented
+        - settings
+      operationId: putCustomerContractSettingsVendorV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CustomerContractSettings'
+        description: This is a generated entry and needs to be described.
+  /api/v3/vendor/contracts/{contractId}/settings/monitoring:
+    x-audience: Internal
+    put:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - settings
+      operationId: putMonitoringSettingsVendorV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - settings
+      operationId: getMonitoringSettingsVendorV3
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+  /api/v3/vendor/contracts/{contractId}/settings/offerretention:
+    x-audience: Internal
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - settings
       operationId: getOfferRetentionSettingsVendorV3
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: contractType
-        required: true
-        schema:
-          enum:
-          - Pricemonitor for manufacturers
-          - Pricemonitor for resellers
-          type: string
-        style: form
+        - in: query
+          name: contractType
+          required: true
+          schema:
+            type: string
+            enum:
+              - Pricemonitor for manufacturers
+              - Pricemonitor for resellers
+    put:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - settings
-    put:
+        - internal
+        - undocumented
+        - settings
       operationId: putOfferRetentionSettingsVendorV3
       parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: contractType
-        required: true
-        schema:
-          enum:
-          - Pricemonitor for manufacturers
-          - Pricemonitor for resellers
-          type: string
-        style: form
+        - in: query
+          name: contractType
+          required: true
+          schema:
+            type: string
+            enum:
+              - Pricemonitor for manufacturers
+              - Pricemonitor for resellers
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - settings
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
   /controlpanel/api/companies/{companyId}:
+    x-audience: Internal
     get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - companies
       operationId: getCompany
-      parameters:
-      - description: ID of a company
-        example: 1
-        explode: false
-        in: path
-        name: companyId
-        required: true
-        schema:
-          format: int64
-          type: integer
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - companies
+    parameters:
+      - $ref: '#/components/parameters/companyIdParam'
   /controlpanel/api/companies/{companyId}/users:
+    x-audience: Internal
     get:
-      operationId: getUsers
-      parameters:
-      - description: ID of a company
-        example: 1
-        explode: false
-        in: path
-        name: companyId
-        required: true
-        schema:
-          format: int64
-          type: integer
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - companies
+        - internal
+        - undocumented
+        - companies
+      operationId: getUsers
+    parameters:
+      - $ref: '#/components/parameters/companyIdParam'
   /controlpanel/api/companies/{companyId}/users/{userId}:
+    x-audience: Internal
     delete:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - companies
       operationId: removeUser
-      parameters:
-      - description: ID of a company
-        example: 1
-        explode: false
-        in: path
-        name: companyId
-        required: true
-        schema:
-          format: int64
-          type: integer
-        style: simple
-      - explode: false
-        in: path
+    parameters:
+      - $ref: '#/components/parameters/companyIdParam'
+      - in: path
         name: userId
         required: true
         schema:
-          format: int64
           type: integer
-        style: simple
+          format: int64
+  /controlpanel/api/tasks:
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - companies
-  /controlpanel/api/tasks:
-    get:
+        - internal
+        - undocumented
+        - controlpanel
       operationId: getAllTasks
       parameters:
-      - explode: true
-        in: query
-        name: contractId
-        required: true
-        schema:
-          items:
+        - in: query
+          name: contractId
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+        - in: query
+          name: taskId
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+        - in: query
+          name: taskType
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+        - in: query
+          name: taskState
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+        - in: query
+          name: minCreationDate
+          required: false
+          schema:
             type: string
-          type: array
-        style: form
-      - explode: true
-        in: query
-        name: taskId
-        required: true
-        schema:
-          items:
+            format: date-time
+        - in: query
+          name: maxCreationDate
+          required: false
+          schema:
             type: string
-          type: array
-        style: form
-      - explode: true
-        in: query
-        name: taskType
-        required: true
-        schema:
-          items:
-            type: string
-          type: array
-        style: form
-      - explode: true
-        in: query
-        name: taskState
-        required: true
-        schema:
-          items:
-            type: string
-          type: array
-        style: form
-      - explode: true
-        in: query
-        name: minCreationDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: maxCreationDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: limit
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
+            format: date-time
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: integer
+            format: int32
+  /controlpanel/api/tasks/stats:
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - controlpanel
-  /controlpanel/api/tasks/stats:
-    get:
+        - internal
+        - undocumented
+        - controlpanel
       operationId: getTasksStats
       parameters:
-      - explode: true
-        in: query
-        name: sinceSeconds
-        required: true
-        schema:
-          format: int32
-          type: integer
-        style: form
+        - in: query
+          name: sinceSeconds
+          required: true
+          schema:
+            type: integer
+            format: int32
+  /controlpanel/api/users/{email}:
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - controlpanel
-  /controlpanel/api/users/{email}:
-    get:
+        - internal
+        - undocumented
+        - controlpanel
       operationId: getUser
-      parameters:
-      - explode: false
-        in: path
+    parameters:
+      - in: path
         name: email
         required: true
         schema:
           type: string
-        style: simple
+  /controlpanel/companies/{id}/users/{email}:
+    x-audience: Internal
+    put:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - controlpanel
-  /controlpanel/companies/{id}/users/{email}:
-    put:
+        - internal
+        - undocumented
+        - controlpanel
       operationId: addCompanyUser
-      parameters:
-      - explode: false
-        in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: This is a generated entry and needs to be described.
+    parameters:
+      - in: path
         name: id
         required: true
         schema:
-          format: int32
           type: integer
-        style: simple
-      - explode: false
-        in: path
+          format: int32
+      - in: path
         name: email
         required: true
         schema:
           type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-        description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - controlpanel
   /controlpanel/users/{email}/authtokens:
+    x-audience: Internal
     post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - controlpanel
       operationId: createAuthToken
-      parameters:
-      - explode: false
-        in: path
-        name: email
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - controlpanel
+    parameters:
+      - in: path
+        name: email
+        required: true
+        schema:
+          type: string
   /controlpanel/users/{email}/authtokens/{token}:
+    x-audience: Internal
     delete:
-      operationId: deleteAuthToken
-      parameters:
-      - explode: false
-        in: path
-        name: email
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
-        name: token
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - controlpanel
+        - internal
+        - undocumented
+        - controlpanel
+      operationId: deleteAuthToken
     put:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - internal
+        - undocumented
+        - controlpanel
       operationId: updateAuthToken
-      parameters:
-      - explode: false
-        in: path
-        name: email
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: false
-        in: path
-        name: token
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               type: object
         description: This is a generated entry and needs to be described.
+    parameters:
+      - in: path
+        name: email
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: token
+        required: true
+        schema:
+          type: string
+  /controlpanel/vendorexport/{vendor}:
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - controlpanel
-  /controlpanel/vendorexport/{vendor}:
-    get:
+        - internal
+        - undocumented
+        - controlpanel
       operationId: vendorData
       parameters:
-      - explode: false
-        in: path
+        - in: query
+          name: minPrice
+          required: true
+          schema:
+            type: number
+            format: double
+        - in: query
+          name: maxPrice
+          required: true
+          schema:
+            type: number
+            format: double
+    parameters:
+      - in: path
         name: vendor
         required: true
         schema:
           type: string
-        style: simple
-      - explode: true
-        in: query
-        name: minPrice
-        required: true
-        schema:
-          format: double
-          type: number
-        style: form
-      - explode: true
-        in: query
-        name: maxPrice
-        required: true
-        schema:
-          format: double
-          type: number
-        style: form
+  /controlpanel/vendors:
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - internal
-      - undocumented
-      - controlpanel
-  /controlpanel/vendors:
-    get:
+        - internal
+        - undocumented
+        - controlpanel
       operationId: listVendors
       parameters:
-      - explode: true
-        in: query
-        name: nameFilter
-        required: true
-        schema:
-          type: string
-        style: form
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - internal
-      - undocumented
-      - controlpanel
+        - in: query
+          name: nameFilter
+          required: true
+          schema:
+            type: string
   /login:
+    x-audience: Internal
     post:
-      operationId: authenticate
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: Authenticate with the API and create a session
-      security: []
       tags:
-      - undocumented
-      - account
-      - internal
+        - undocumented
+        - account
+        - internal
+      operationId: authenticate
+      security: []
   /logout:
     post:
+      x-audience: Internal
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Deauthenticate with the API and destroy the current session.
+      tags:
+        - undocumented
+        - account
+        - internal
       operationId: logout
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: Deauthenticate with the API and destroy the current session
       security: []
-      tags:
-      - undocumented
-      - account
-      - internal
   /api/account/password:
+    x-audience: Internal
     put:
+      x-audience: Internal
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Change the current user's password.
+      tags:
+        - undocumented
+        - account
+        - internal
       operationId: changePassword
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: Change the current users password
-      tags:
-      - undocumented
-      - account
   /api/2/v/contracts/{contractId}/shop-integration/{path}:
+    x-audience: Internal
     get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - undocumented
+        - internal
       operationId: shopIntegrationGetRequest
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: The shop-integration path to be called
-        explode: false
-        in: path
-        name: path
-        required: true
-        schema:
-          type: string
-        style: simple
+    post:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - undocumented
-      - internal
-    post:
+        - undocumented
+        - internal
       operationId: shopIntegrationPostRequest
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
       - description: The shop-integration path to be called
-        explode: false
         in: path
         name: path
         required: true
         schema:
           type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - undocumented
-      - internal
   /api/2/log/messages:
+    x-audience: Internal
     post:
-      operationId: postLogMessage
+      deprecated: true
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - undocumented
-      - logs
+        - deprecated
+        - logs
+      operationId: postLogMessage
+      summary: Log a message
+      description: Logs a message.
   /api/2/domains:
     get:
-      operationId: allAvailablePortals
+      deprecated: true
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                type: object
-          description: This is a generated entry and needs to be described.
+                type: array
+                items:
+                  type: string
+          description: A list of all available domains for monitoring.
+      summary: Gets a list of all available domains (V2)
+      description: Gets a list of all available domains for monitoring.
       tags:
-      - undocumented
-      - settings
+        - deprecated
+        - domains
+      operationId: getAllDomainsV2
   /api/v3/vendor/contracts/{contractId}/monitoringpipeline/{path}:
+    x-audience: Internal
     post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - undocumented
+        - internal
       operationId: monitoringPipelinePostRequestVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
       - description: The monitoring-pipeline path to be called
-        explode: false
         in: path
         name: path
         required: true
         schema:
           type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - undocumented
-      - internal
   /api/v3/manufacturer/contracts/{contractId}/monitoringpipeline/{path}:
+    x-audience: Internal
     post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - undocumented
+        - internal
       operationId: monitoringPipelinePostRequestManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
       - description: The monitoring-pipeline path to be called
-        explode: false
         in: path
         name: path
         required: true
         schema:
           type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - undocumented
-      - internal
   /api/v3/vendor/contracts/{contractId}/scheduler/{path}:
-    delete:
-      operationId: schedulerDeleteRequestVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: The scheduler path to be called
-        explode: false
-        in: path
-        name: path
-        required: true
-        schema:
-          type: string
-        style: simple
+    x-audience: Internal
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - undocumented
-      - internal
-    get:
+        - undocumented
+        - internal
       operationId: schedulerGetRequestVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: The scheduler path to be called
-        explode: false
-        in: path
-        name: path
-        required: true
-        schema:
-          type: string
-        style: simple
+    post:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - undocumented
-      - internal
-    post:
+        - undocumented
+        - internal
       operationId: schedulerPostRequestVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: The scheduler path to be called
-        explode: false
-        in: path
-        name: path
-        required: true
-        schema:
-          type: string
-        style: simple
+    put:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - undocumented
-      - internal
-    put:
+        - undocumented
+        - internal
       operationId: schedulerPutRequestVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: The scheduler path to be called
-        explode: false
-        in: path
-        name: path
-        required: true
-        schema:
-          type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - undocumented
-      - internal
-  /api/v3/manufacturer/contracts/{contractId}/scheduler/{path}:
     delete:
-      operationId: schedulerDeleteRequestManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: The scheduler path to be called
-        explode: false
-        in: path
-        name: path
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - undocumented
-      - internal
+        - undocumented
+        - internal
+      operationId: schedulerDeleteRequestVendorV3
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - description: The scheduler path to be called
+        in: path
+        name: path
+        required: true
+        schema:
+          type: string
+  /api/v3/manufacturer/contracts/{contractId}/scheduler/{path}:
+    x-audience: Internal
     get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - undocumented
+        - internal
       operationId: schedulerGetRequestManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: The scheduler path to be called
-        explode: false
-        in: path
-        name: path
-        required: true
-        schema:
-          type: string
-        style: simple
+    post:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - undocumented
-      - internal
-    post:
+        - undocumented
+        - internal
       operationId: schedulerPostRequestManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: The scheduler path to be called
-        explode: false
-        in: path
-        name: path
-        required: true
-        schema:
-          type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: This is a generated entry and needs to be described.
-      tags:
-      - undocumented
-      - internal
     put:
-      operationId: schedulerPutRequestManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: The scheduler path to be called
-        explode: false
-        in: path
-        name: path
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: object
           description: This is a generated entry and needs to be described.
       tags:
-      - undocumented
-      - internal
+        - undocumented
+        - internal
+      operationId: schedulerPutRequestManufacturerV3
+    delete:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: This is a generated entry and needs to be described.
+      tags:
+        - undocumented
+        - internal
+      operationId: schedulerDeleteRequestManufacturerV3
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - description: The scheduler path to be called
+        in: path
+        name: path
+        required: true
+        schema:
+          type: string
   /api/v3/vendor/contracts/{contractId}/looker/sso/embed/url:
+    x-audience: Internal
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
     post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmbedSSOUrlResponseV3ApiResponse'
+          description: Signed embed SSO url for Looker.
+      tags:
+        - internal
+        - looker
       operationId: postEmbedSSOUrlVendor
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostEmbedSSOUrlRequestV3'
         description: Payload for retrieving a signed embed SSO url using Looker API.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EmbedSSOUrlResponseV3ApiResponse'
-          description: Signed embed SSO url for Looker.
       summary: Retrieve an embed SSO url for Looker.
-      tags:
-      - internal
-      - looker
   /api/v3/manufacturer/contracts/{contractId}/looker/sso/embed/url:
+    x-audience: Internal
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
     post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmbedSSOUrlResponseV3ApiResponse'
+          description: Signed embed SSO url for Looker.
+      tags:
+        - internal
+        - looker
       operationId: postEmbedSSOUrlManufacturer
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostEmbedSSOUrlRequestV3'
         description: Payload for retrieving a signed embed SSO url using Looker API.
+      summary: Retrieve an embed SSO url for Looker.
+  /api/v3/companies/{companyId}/amazon/marketplace:
+    x-audience: Internal
+    parameters:
+      - $ref: '#/components/parameters/companyIdParam'
+    post:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EmbedSSOUrlResponseV3ApiResponse'
-          description: Signed embed SSO url for Looker.
-      summary: Retrieve an embed SSO url for Looker.
+                $ref: '#/components/schemas/ActivateMarketplaceResponseV3ApiResponse'
+          description: Successfully activated marketplace of a customer in our system.
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: |
+            - Specified marketplace already activated.
+            - Invalid marketplace country code is specified.
+            - Given company is not registered with our system. One must register his seller central account with our system.
       tags:
-      - internal
-      - looker
-  /api/v3/companies/{companyId}/amazon/marketplace:
-    post:
+        - amazon-integration
+        - internal
       operationId: postActivateMarketplaceVendorV3
-      parameters:
-      - description: ID of a company
-        example: 1
-        explode: false
-        in: path
-        name: companyId
-        required: true
-        schema:
-          format: int64
-          type: integer
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostActivateMarketplaceRequestV3'
         description: Marketplace of a customer to be activated.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ActivateMarketplaceResponseV3ApiResponse'
-          description: Successfully activated marketplace of a customer in our system.
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: |
-            - Specified marketplace already activated.
-            - Invalid marketplace country code is specified.
-            - Given company is not registered with our system. One must register his seller central account with our system.
       summary: |
         Activate marketplace of a customer in our system. By activation, it means that our system can
         write prices back into the customer's Amazon shop.
-      tags:
-      - amazon-integration
-      - internal
   /api/v3/companies/{companyId}/amazon/marketplace/{marketplaceCountryCode}/contracts/{contractId}:
-    get:
-      operationId: getMarketplaceActivationStatus
-      parameters:
-      - description: Marketplace country code. You can view complete list here. https://developer-docs.amazon.com/sp-api/docs/marketplace-ids.
-          Currently, only Europe as a region is supported.
-        example: DE
-        explode: false
-        in: path
+    x-audience: Internal
+    parameters:
+      - in: path
         name: marketplaceCountryCode
-        required: true
         schema:
           type: string
-        style: simple
-      - description: ID of a company
-        example: 1
-        explode: false
-        in: path
-        name: companyId
         required: true
-        schema:
-          format: int64
-          type: integer
-        style: simple
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+        description: Marketplace country code. You can view complete list here. https://developer-docs.amazon.com/sp-api/docs/marketplace-ids. Currently, only Europe as a region is supported.
+        example: DE
+      - $ref: '#/components/parameters/companyIdParam'
+      - $ref: '#/components/parameters/contractIdParam'
+    get:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ActivateMarketplaceResponseV3ApiResponse'
           description: Marketplace activation status.
-        "400":
+        '400':
           content:
             application/json:
               schema:
@@ -8042,502 +5998,319 @@ paths:
             - Specified marketplace already activated.
             - Invalid marketplace country code is specified.
             - Given company is not registered with our system. One must register his seller central account with our system.
+      tags:
+        - amazon-integration
+        - internal
+      operationId: getMarketplaceActivationStatus
       summary: |
         Get marketplace activation status of a customer in our system.
-      tags:
-      - amazon-integration
-      - internal
   /api/v3/companies/{companyId}/amazon/authorization/status:
+    x-audience: Internal
+    parameters:
+      - $ref: '#/components/parameters/companyIdParam'
     get:
-      operationId: getAuthorizationStatusVendorV3
-      parameters:
-      - description: ID of a company
-        example: 1
-        explode: false
-        in: path
-        name: companyId
-        required: true
-        schema:
-          format: int64
-          type: integer
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetAuthorizationStatusResponseV3ApiResponse'
           description: Authorization status of a customer on Amazon.
+      tags:
+        - amazon-integration
+        - internal
+      operationId: getAuthorizationStatusVendorV3
       summary: |
         Get OAuth authorization status for customer's Amazon seller central account.
         For setting up OAuth authorization, have a look at the endpoint
         POST /api/v3/companies/{companyId}/amazon/authorization.
-      tags:
-      - amazon-integration
-      - internal
   /api/v3/companies/{companyId}/amazon/authorization:
+    x-audience: Internal
+    parameters:
+      - $ref: '#/components/parameters/companyIdParam'
     post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostAuthorizeSellerResponseV3ApiResponse'
+          description: Successfully authorized customer's Amazon seller central account.
+      tags:
+        - amazon-integration
+        - internal
       operationId: postAuthorizeSellerVendorV3
-      parameters:
-      - description: ID of a company
-        example: 1
-        explode: false
-        in: path
-        name: companyId
-        required: true
-        schema:
-          format: int64
-          type: integer
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostAuthorizeSellerRequestV3'
         description: Customer's Amazon seller central account to be authorized.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostAuthorizeSellerResponseV3ApiResponse'
-          description: Successfully authorized customer's Amazon seller central account.
       summary: |
         Set up an OAuth authorization for a customer's Amazon Seller Central account.
         It establishes a connection between our system and the customer's Amazon shop using the Amazon SP-API.
         Once connected, our system can write prices back to the customer's Amazon shop, allowing them to benefit
         from our price recommendations.
-      tags:
-      - amazon-integration
-      - internal
   /api/v3/vendor/contracts/{contractId}/settings/monitoringschedules:
-    get:
-      operationId: getMonitoringSchedulesVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
+    x-audience: Internal
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+    post:
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetMonitoringSchedulesApiResponse'
-          description: List of monitoring schedules.
-      summary: Get all the monitoring schedules for a specified contract.
+                $ref: '#/components/schemas/PutMonitoringSchedulesApiResponse'
+          description: Monitoring schedule has been created successfully.
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Monitoring schedule could not be created due to an internal server error.
       tags:
-      - monitoring-schedules
-      - internal
-    post:
+        - internal
+        - monitoring-schedules
       operationId: postMonitoringScheduleVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostMonitoringScheduleRequestV3'
         description: Request body for creating monitoring schedule.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PutMonitoringSchedulesApiResponse'
-          description: Monitoring schedule has been created successfully.
-        "503":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: Monitoring schedule could not be created due to an internal
-            server error.
       summary: Add a monitoring schedule for a given contract.
-      tags:
-      - internal
-      - monitoring-schedules
-  /api/v3/vendor/contracts/{contractId}/settings/monitoringschedules/{scheduleId}:
-    delete:
-      operationId: deleteMonitoringScheduleVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: ID of a monitoring schedule
-        explode: false
-        in: path
-        name: scheduleId
-        required: true
-        schema:
-          type: integer
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.DeleteByNumericIdApiResponse'
-          description: Monitoring schedule has been deleted successfully.
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: Specified monitoring schedule does not exist.
-        "503":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: Monitoring schedule could not be deleted due to an internal
-            server error.
-      summary: Delete a monitoring schedule for a given contract.
-      tags:
-      - internal
-      - monitoring-schedules
-    put:
-      operationId: putMonitoringScheduleVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: ID of a monitoring schedule
-        explode: false
-        in: path
-        name: scheduleId
-        required: true
-        schema:
-          type: integer
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostMonitoringScheduleRequestV3'
-        description: Request body for updating monitoring schedule.
-      responses:
-        "201":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PutMonitoringSchedulesApiResponse'
-          description: Monitoring schedule has been updated successfully.
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: Specified monitoring schedule does not exist.
-        "503":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: Monitoring schedule could not be updated due to an internal
-            server error.
-      summary: Update a monitoring schedule for a given contract.
-      tags:
-      - internal
-      - monitoring-schedules
-  /api/v3/vendor/contracts/{contractId}/settings/monitoringschedules/{scheduleId}/execute:
-    post:
-      operationId: executeMonitoringScheduleVendorV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: ID of a monitoring schedule
-        explode: false
-        in: path
-        name: scheduleId
-        required: true
-        schema:
-          type: integer
-        style: simple
-      - explode: true
-        in: query
-        name: triggerFollowUpTask
-        required: false
-        schema:
-          description: A flag to trigger follow up tasks once current is completed.
-            By default it is set to true.
-          type: boolean
-        style: form
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EmptyApiResponse'
-          description: Monitoring task was successfully created and is executing
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: Couldn't find any monitoring schedules for given schedule id.
-            No monitoring task was created
-      summary: Trigger a monitoring pipeline task for vendor for configured monitoring
-        schedule
-      tags:
-      - internal
-      - monitoring-schedules
-  /api/v3/manufacturer/contracts/{contractId}/settings/monitoringschedules:
     get:
-      operationId: getMonitoringSchedulesManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetMonitoringSchedulesApiResponse'
           description: List of monitoring schedules.
+      tags:
+        - monitoring-schedules
+        - internal
+      operationId: getMonitoringSchedulesVendorV3
       summary: Get all the monitoring schedules for a specified contract.
-      tags:
-      - monitoring-schedules
-      - internal
-    post:
-      operationId: postMonitoringScheduleManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostMonitoringScheduleRequestV3'
-        description: Request body for creating monitoring schedule.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PutMonitoringSchedulesApiResponse'
-          description: Monitoring schedule has been created successfully.
-      summary: Add a monitoring schedule for a given contract.
-      tags:
-      - internal
-      - monitoring-schedules
-  /api/v3/manufacturer/contracts/{contractId}/settings/monitoringschedules/{scheduleId}:
+  /api/v3/vendor/contracts/{contractId}/settings/monitoringschedules/{scheduleId}:
+    x-audience: Internal
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - $ref: '#/components/parameters/scheduleIdParam'
     delete:
-      operationId: deleteMonitoringScheduleManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: ID of a monitoring schedule
-        explode: false
-        in: path
-        name: scheduleId
-        required: true
-        schema:
-          type: integer
-        style: simple
+      tags:
+        - internal
+        - monitoring-schedules
+      operationId: deleteMonitoringScheduleVendorV3
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.DeleteByNumericIdApiResponse'
           description: Monitoring schedule has been deleted successfully.
-        "404":
+        '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
           description: Specified monitoring schedule does not exist.
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Monitoring schedule could not be deleted due to an internal server error.
       summary: Delete a monitoring schedule for a given contract.
-      tags:
-      - internal
-      - monitoring-schedules
     put:
-      operationId: putMonitoringScheduleManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: ID of a monitoring schedule
-        explode: false
-        in: path
-        name: scheduleId
-        required: true
-        schema:
-          type: integer
-        style: simple
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PutMonitoringSchedulesApiResponse'
+          description: Monitoring schedule has been updated successfully.
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Specified monitoring schedule does not exist.
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Monitoring schedule could not be updated due to an internal server error.
+      tags:
+        - internal
+        - monitoring-schedules
+      operationId: putMonitoringScheduleVendorV3
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostMonitoringScheduleRequestV3'
         description: Request body for updating monitoring schedule.
-      responses:
-        "201":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PutMonitoringSchedulesApiResponse'
-          description: Monitoring schedule has been updated successfully.
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: Specified monitoring schedule does not exist.
       summary: Update a monitoring schedule for a given contract.
-      tags:
-      - internal
-      - monitoring-schedules
-  /api/v3/manufacturer/contracts/{contractId}/settings/monitoringschedules/{scheduleId}/execute:
+  /api/v3/vendor/contracts/{contractId}/settings/monitoringschedules/{scheduleId}/execute:
+    x-audience: Internal
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - $ref: '#/components/parameters/scheduleIdParam'
+      - $ref: '#/components/parameters/triggerFollowUpTask'
     post:
-      operationId: executeMonitoringScheduleManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: ID of a monitoring schedule
-        explode: false
-        in: path
-        name: scheduleId
-        required: true
-        schema:
-          type: integer
-        style: simple
-      - explode: true
-        in: query
-        name: triggerFollowUpTask
-        required: false
-        schema:
-          description: A flag to trigger follow up tasks once current is completed.
-            By default it is set to true.
-          type: boolean
-        style: form
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/EmptyApiResponse'
           description: Monitoring task was successfully created and is executing
-        "404":
+        '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
-          description: Couldn't find any monitoring schedules for given schedule id.
-            No monitoring task was created
-      summary: Trigger a monitoring pipeline task for manufacturer for configured
-        monitoring schedule
+          description: Couldn't find any monitoring schedules for given schedule id. No monitoring task was created
       tags:
-      - internal
-      - monitoring-schedules
-  /api/v3/vendor/contracts/{contractId}/tasks/preprocessing:
+        - internal
+        - monitoring-schedules
+      operationId: executeMonitoringScheduleVendorV3
+      summary: Trigger a monitoring pipeline task for vendor for configured monitoring schedule
+  /api/v3/manufacturer/contracts/{contractId}/settings/monitoringschedules:
+    x-audience: Internal
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
     post:
-      operationId: publishPreprocessingTaskVendorV3
-      parameters:
-      - description: The timespan, in minutes, for considering offers in preprocessing.
-          Allowed value is between 1 and 10080
-        explode: true
-        in: query
-        name: retrospectiveInMinutes
-        required: true
-        schema:
-          maximum: 10080
-          minimum: 1
-          type: integer
-        style: form
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - explode: true
-        in: query
-        name: triggerFollowUpTask
-        required: false
-        schema:
-          description: A flag to trigger follow up tasks once current is completed.
-            By default it is set to true.
-          type: boolean
-        style: form
       responses:
-        "200":
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PutMonitoringSchedulesApiResponse'
+          description: Monitoring schedule has been created successfully.
+      tags:
+        - internal
+        - monitoring-schedules
+      operationId: postMonitoringScheduleManufacturerV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostMonitoringScheduleRequestV3'
+        description: Request body for creating monitoring schedule.
+      summary: Add a monitoring schedule for a given contract.
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetMonitoringSchedulesApiResponse'
+          description: List of monitoring schedules.
+      tags:
+        - monitoring-schedules
+        - internal
+      operationId: getMonitoringSchedulesManufacturerV3
+      summary: Get all the monitoring schedules for a specified contract.
+  /api/v3/manufacturer/contracts/{contractId}/settings/monitoringschedules/{scheduleId}:
+    x-audience: Internal
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - $ref: '#/components/parameters/scheduleIdParam'
+    delete:
+      tags:
+        - internal
+        - monitoring-schedules
+      operationId: deleteMonitoringScheduleManufacturerV3
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.DeleteByNumericIdApiResponse'
+          description: Monitoring schedule has been deleted successfully.
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Specified monitoring schedule does not exist.
+      summary: Delete a monitoring schedule for a given contract.
+    put:
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PutMonitoringSchedulesApiResponse'
+          description: Monitoring schedule has been updated successfully.
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Specified monitoring schedule does not exist.
+      tags:
+        - internal
+        - monitoring-schedules
+      operationId: putMonitoringScheduleManufacturerV3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostMonitoringScheduleRequestV3'
+        description: Request body for updating monitoring schedule.
+      summary: Update a monitoring schedule for a given contract.
+  /api/v3/manufacturer/contracts/{contractId}/settings/monitoringschedules/{scheduleId}/execute:
+    x-audience: Internal
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - $ref: '#/components/parameters/scheduleIdParam'
+      - $ref: '#/components/parameters/triggerFollowUpTask'
+    post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptyApiResponse'
+          description: Monitoring task was successfully created and is executing
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Couldn't find any monitoring schedules for given schedule id. No monitoring task was created
+      tags:
+        - internal
+        - monitoring-schedules
+      operationId: executeMonitoringScheduleManufacturerV3
+      summary: Trigger a monitoring pipeline task for manufacturer for configured monitoring schedule
+  /api/v3/vendor/contracts/{contractId}/tasks/preprocessing:
+    x-audience: Internal
+    parameters:
+      - in: query
+        name: retrospectiveInMinutes
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 10080
+        required: true
+        description: The timespan, in minutes, for considering offers in preprocessing. Allowed value is between 1 and 10080
+      - $ref: '#/components/parameters/contractIdParam'
+      - $ref: '#/components/parameters/triggerFollowUpTask'
+    post:
+      responses:
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/EmptyApiResponse'
           description: Preprocessing task created successfully
-        "400":
+        '400':
           content:
             application/json:
               schema:
@@ -8545,245 +6318,168 @@ paths:
           description: |
             - Invalid retrospective value.
             - No retrospective value is specified.
-      summary: Publish a preprocessing task for vendor.
       tags:
-      - internal
-      - preprocessing
+        - internal
+        - preprocessing
+      operationId: publishPreprocessingTaskVendorV3
+      summary: Publish a preprocessing task for vendor.
   /api/v3/manufacturer/contracts/{contractId}/vendors:
+    x-audience: Internal
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
     get:
-      operationId: getVendorShopMappingsManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetVendorShopMappingsApiResponse'
           description: List of vendors along with their associated shops.
-      summary: Get all the vendors along with their associated shops for a specified
-        contract.
       tags:
-      - vendor-shop-mapping
-      - internal
+        - vendor-shop-mapping
+        - internal
+      operationId: getVendorShopMappingsManufacturerV3
+      summary: Get all the vendors along with their associated shops for a specified contract.
     post:
-      operationId: postVendorShopMappingManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostVendorShopMappingRequestV3'
-        description: Request body for creating a new vendor and associate shops with
-          it. Please note that atleast one shop is required for a successful creation.
+        description: Request body for creating a new vendor and associate shops with it. Please note that atleast one shop is required for a successful creation.
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/VendorShopMappingV3ApiResponse'
           description: Vendor shop mapping has been successfully created.
-        "400":
+        '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
-          description: The specified vendor name is empty. Or the specified shops
-            are empty.
-        "409":
+          description: The specified vendor name is empty. Or the specified shops are empty.
+        '409':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
           description: The specified vendor name already exists in our system.
-        "422":
+        '422':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
           description: The specified shops do not exist in our system.
-      summary: Add a new vendor for a given contract and associate shops with the
-        given vendor.
       tags:
-      - internal
-      - vendor-shop-mapping
+        - internal
+        - vendor-shop-mapping
+      operationId: postVendorShopMappingManufacturerV3
+      summary: Add a new vendor for a given contract and associate shops with the given vendor.
   /api/v3/manufacturer/contracts/{contractId}/vendors/{vendorId}:
-    delete:
-      operationId: deleteVendorShopMappingManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: ID of vendor shop mapping
-        example: 1
-        explode: false
-        in: path
-        name: vendorId
-        required: true
-        schema:
-          format: int64
-          type: integer
-        style: simple
+    x-audience: Internal
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
+      - $ref: '#/components/parameters/vendorIdParam'
+    put:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostVendorShopMappingRequestV3'
+        description: Request body for updating an existing vendor and associate shops with it. Please note that atleast one shop is required for a successful creation.
       responses:
-        "200":
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorShopMappingV3ApiResponse'
+          description: Vendor shop mapping has been successfully updated.
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: The specified vendor name is empty. Or the specified shops are empty.
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: The specified vendor name already exists in our system.
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: The specified shops do not exist in our system.
+      tags:
+        - internal
+        - vendor-shop-mapping
+      operationId: putVendorShopMappingManufacturerV3
+      summary: Update an existing vendor for a given contract and associate shops with the given vendor.
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorShopMappingV3ApiResponse'
+          description: Get vendor along with their associated shop for given vendor id and contract.
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Vendor doesn't exist for given vendor id.
+      tags:
+        - vendor-shop-mapping
+        - internal
+      operationId: getVendorShopMappingManufacturerV3
+      summary: Get vendor along with their associated shop for given vendor id and contract.
+    delete:
+      tags:
+        - vendor-shop-mapping
+        - internal
+      operationId: deleteVendorShopMappingManufacturerV3
+      responses:
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.DeleteByNumericIdApiResponse'
           description: A vendor and associated shops have been deleted successfully.
-        "404":
+        '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
           description: Specified vendor does not exist.
       summary: Delete a vendor and associated shops for a given contract.
-      tags:
-      - vendor-shop-mapping
-      - internal
-    get:
-      operationId: getVendorShopMappingManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: ID of vendor shop mapping
-        example: 1
-        explode: false
-        in: path
-        name: vendorId
-        required: true
-        schema:
-          format: int64
-          type: integer
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VendorShopMappingV3ApiResponse'
-          description: Get vendor along with their associated shop for given vendor
-            id and contract.
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: Vendor doesn't exist for given vendor id.
-      summary: Get vendor along with their associated shop for given vendor id and
-        contract.
-      tags:
-      - vendor-shop-mapping
-      - internal
-    put:
-      operationId: putVendorShopMappingManufacturerV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: ID of vendor shop mapping
-        example: 1
-        explode: false
-        in: path
-        name: vendorId
-        required: true
-        schema:
-          format: int64
-          type: integer
-        style: simple
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostVendorShopMappingRequestV3'
-        description: Request body for updating an existing vendor and associate shops
-          with it. Please note that atleast one shop is required for a successful
-          creation.
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VendorShopMappingV3ApiResponse'
-          description: Vendor shop mapping has been successfully updated.
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: The specified vendor name is empty. Or the specified shops
-            are empty.
-        "409":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: The specified vendor name already exists in our system.
-        "422":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-          description: The specified shops do not exist in our system.
-      summary: Update an existing vendor for a given contract and associate shops
-        with the given vendor.
-      tags:
-      - internal
-      - vendor-shop-mapping
   /api/v3/account:
+    x-audience: Internal
     post:
+      tags:
+        - account
+        - internal
       operationId: postAccountV3
+      summary: Create a new user account
+      security: []
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostAccountRequestV3'
-        description: Request body for creating a new user account. It must contain
-          name, email and password.
+        description: Request body for creating a new user account. It must contain name, email and password.
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/PostAccountResponseV3ApiResponse'
           description: The account information of the newly created account.
-        "400":
+        '400':
           content:
             application/json:
               schema:
@@ -8796,82 +6492,46 @@ paths:
             - The password length is less than 6 characters long
             - The enpoint was requested too often
             - The given email address already exists
-      security: []
-      summary: Create a new user account
-      tags:
-      - account
   /api/v3/vendor/contracts/{contractId}/products/amazon/buybox/stats:
+    parameters:
+      - $ref: '#/components/parameters/contractIdParam'
     get:
+      parameters:
+        - $ref: '#/components/parameters/startDate'
+        - $ref: '#/components/parameters/endDate'
+        - description: Where to start fetching the amazon buybox statistics. Must be positive. Default value is 0.
+          in: query
+          name: start
+          required: false
+          example: 0
+          schema:
+            format: int32
+            type: integer
+        - description: Maximum number of results. Must be positive and not bigger than 50,000. Default value is 50,000.
+          in: query
+          name: limit
+          required: false
+          example: 50000
+          schema:
+            format: int32
+            type: integer
+      tags:
+        - products
+      operationId: getAmazonBuyboxProductStatsV3
+      summary: Retrieve latest Amazon Buybox statistics per product and amazon domain for a given time range.
       description: |
         Provides latest Amazon Buybox statistics
         - product is in Amazon Buybox for Prime users
         - product is in Amazon Buybox for Non-Prime users
         per product on Amazon domain for a given time range.
-      operationId: getAmazonBuyboxProductStatsV3
-      parameters:
-      - description: ID of the contract
-        example: qbcxvb
-        explode: false
-        in: path
-        name: contractId
-        required: true
-        schema:
-          type: string
-        style: simple
-      - description: Timestamp of start of time range, formatted as ISO Date (i.e.
-          2018-04-06T13:46:13Z) in UTC. If this value is omitted and {endDate} is
-          given, {startDate} is set to {endDate} - 48 hours. If both values are omitted,
-          the range is 'NOW - 48 hours to NOW'.
-        explode: true
-        in: query
-        name: startDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - description: Timestamp of end of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z)
-          in UTC. If this value is omitted and {startDate} is given, {endDate} is
-          set to {startDate} + 48 hours. If both values are omitted, the range is
-          'NOW - 48 hours to NOW'.
-        explode: true
-        in: query
-        name: endDate
-        required: false
-        schema:
-          format: date-time
-          type: string
-        style: form
-      - description: Where to start fetching the amazon buybox statistics. Must be
-          positive. Default value is 0.
-        example: 0
-        explode: true
-        in: query
-        name: start
-        required: false
-        schema:
-          format: int32
-          type: integer
-        style: form
-      - description: Maximum number of results. Must be positive and not bigger than
-          50,000. Default value is 50,000.
-        example: 50000
-        explode: true
-        in: query
-        name: limit
-        required: false
-        schema:
-          format: int32
-          type: integer
-        style: form
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/AmazonBuyboxProductStatsV3ApiResponse'
           description: List of Amazon Buybox statistics per product
-        "400":
+        '400':
           content:
             application/json:
               schema:
@@ -8884,302 +6544,165 @@ paths:
             - The start parameter is negative
             - The limit parameter is negative and larger than 50,000
             - The contract has more than one amazon domain configured.
-      summary: Retrieve latest Amazon Buybox statistics per product and amazon domain
-        for a given time range.
-      tags:
-      - products
 components:
   parameters:
     companyIdParam:
       description: ID of a company
-      example: 1
-      explode: false
       in: path
       name: companyId
       required: true
       schema:
         format: int64
         type: integer
-      style: simple
+      example: 1
     scheduleIdParam:
       description: ID of a monitoring schedule
-      explode: false
       in: path
       name: scheduleId
       required: true
       schema:
         type: integer
-      style: simple
     productIdParam:
       description: ID of the product in pricemonitor
-      example: 862342
-      explode: false
       in: path
       name: productId
       required: true
       schema:
         type: string
-      style: simple
+      example: 862342
     contractIdParam:
       description: ID of the contract
-      example: qbcxvb
-      explode: false
       in: path
       name: contractId
       required: true
       schema:
         type: string
-      style: simple
+      example: qbcxvb
     startDate:
-      description: Timestamp of start of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z)
-        in UTC. If this value is omitted and {endDate} is given, {startDate} is set
-        to {endDate} - 48 hours. If both values are omitted, the range is 'NOW - 48
-        hours to NOW'.
-      explode: true
+      description: Timestamp of start of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z) in UTC. If this value is omitted and {endDate} is given, {startDate} is set to {endDate} - 48 hours. If both values are omitted, the range is 'NOW - 48 hours to NOW'.
       in: query
       name: startDate
       required: false
       schema:
         format: date-time
         type: string
-      style: form
     endDate:
-      description: Timestamp of end of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z)
-        in UTC. If this value is omitted and {startDate} is given, {endDate} is set
-        to {startDate} + 48 hours. If both values are omitted, the range is 'NOW -
-        48 hours to NOW'.
-      explode: true
+      description: Timestamp of end of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z) in UTC. If this value is omitted and {startDate} is given, {endDate} is set to {startDate} + 48 hours. If both values are omitted, the range is 'NOW - 48 hours to NOW'.
       in: query
       name: endDate
       required: false
       schema:
         format: date-time
         type: string
-      style: form
     getOrdersStartDate:
       description: |
         Timestamp of start of time range for fetching orders.
         Formatted as ISO 8601 format with timezone with reference to UTC (e.g. for [Europe/Berlin] in winter time:
         2023-11-01T14:50:45.495+01:00. In summer time: 2023-11-01T14:50:45.495+02:00).
         If this value is omitted then no lower time limit is considered.
-      explode: true
       in: query
       name: startDate
       required: false
       schema:
         format: date-time
         type: string
-      style: form
     getOrdersEndDate:
       description: |
         Timestamp of end of time range for fetching orders.
         Formatted as ISO 8601 format with timezone with reference to UTC (e.g. for [Europe/Berlin] in winter time:
         2023-11-01T14:50:45.495+01:00. In summer time: 2023-11-01T14:50:45.495+02:00).
         If this value is omitted then no upper time limit is considered.
-      explode: true
       in: query
       name: endDate
       required: false
       schema:
         format: date-time
         type: string
-      style: form
     startDateOneWeekMax:
-      description: Timestamp of start of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z)
-        in UTC. If this value is omitted and {endDate} is given, {startDate} is set
-        to {endDate} - 48 hours. If both values are omitted, the range is 'NOW - 48
-        hours to NOW'. The time range may not exceed 1 week.
-      explode: true
+      description: Timestamp of start of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z) in UTC. If this value is omitted and {endDate} is given, {startDate} is set to {endDate} - 48 hours. If both values are omitted, the range is 'NOW - 48 hours to NOW'. The time range may not exceed 1 week.
       in: query
       name: startDate
       required: false
       schema:
         format: date-time
         type: string
-      style: form
     endDateOneWeekMax:
-      description: Timestamp of end of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z)
-        in UTC. If this value is omitted and {startDate} is given, {endDate} is set
-        to {startDate} + 48 hours. If both values are omitted, the range is 'NOW -
-        48 hours to NOW'. The time range may not exceed 1 week.
-      explode: true
+      description: Timestamp of end of time range, formatted as ISO Date (i.e. 2018-04-06T13:46:13Z) in UTC. If this value is omitted and {startDate} is given, {endDate} is set to {startDate} + 48 hours. If both values are omitted, the range is 'NOW - 48 hours to NOW'. The time range may not exceed 1 week.
       in: query
       name: endDate
       required: false
       schema:
         format: date-time
         type: string
-      style: form
     vendorIdParam:
       description: ID of vendor shop mapping
-      example: 1
-      explode: false
       in: path
       name: vendorId
       required: true
       schema:
-        format: int64
         type: integer
-      style: simple
+        format: int64
+      example: 1
     triggerFollowUpTask:
-      explode: true
       in: query
       name: triggerFollowUpTask
-      required: false
       schema:
-        description: A flag to trigger follow up tasks once current is completed.
-          By default it is set to true.
         type: boolean
-      style: form
-  requestBodies:
-    PostOfferStatisticsRequestV31Enriched:
-      content:
-        application/json:
-          example:
-            pagination:
-              start: 0
-              limit: 10
-            range:
-              start: 2023-10-17T08:00:00Z
-              end: 2023-10-19T08:00:00Z
-            filter:
-              oneOf:
-                field: customerProductId
-                values:
-                - "1"
-                - "2"
-                - "3"
-                - "4"
-                - "5"
-                - "6"
-                - "7"
-                - "8"
-                - "9"
-                - "10"
-          schema:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostOfferStatisticsRequestV31'
-      description: |
-        The request body may include an optional products query. If omitted, all products are queried. Currently, product queries can be performed on two attributes:
-          - "customerProductId"
-          - "productId" (Patagona's internal product id; must be a numerical integer)
-
-        Pagination is supported with a maximum limit of 10,000. For optimized performance:
-          - Use a limit of 10,000 products per page when querying all products of a contract.
-          - Prefer using "productId" for queries when a product query is utilized.
-
-        Pagination operates based on the provided products query.
-        This is particularly useful when querying a set of customerProductId's.
-        For chunked requests over a set of ids, it's straightforward to specify up to 10,000 customerProductId's in the query with pagination set at start: 0, limit: 10,000.
-
-        The allowed query pattern is structured as follows:
-
-        { <br>
-        &nbsp;&nbsp;"pagination": { <br>
-        &nbsp;&nbsp;&nbsp;&nbsp;"start": ${start}, <br>
-        &nbsp;&nbsp;&nbsp;&nbsp;"limit": ${limit} <br>
-        &nbsp;&nbsp;}, <br>
-        &nbsp;&nbsp;"range": { <br>
-        &nbsp;&nbsp;&nbsp;&nbsp;"start": ${start}, <br>
-        &nbsp;&nbsp;&nbsp;&nbsp;"end": ${end} <br>
-        &nbsp;&nbsp;}, <br>
-        &nbsp;&nbsp;"filter": { <br>
-        &nbsp;&nbsp;&nbsp;&nbsp;"oneOf": { <br>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"field": "customerProductId", <br>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"values": [${customerProductIds as a list of strings}] <br>
-        &nbsp;&nbsp;&nbsp;&nbsp;} <br>
-        &nbsp;&nbsp;} <br>
-        } <br>
-        <br>
+        description: A flag to trigger follow up tasks once current is completed. By default it is set to true.
   schemas:
     LogMessages:
-      example:
-        messages:
-        - severity: info
-          component: shopware or magento
-          contractId: qbcxvb
-          source: some.domain.name
-          message: Some useful message
-        - severity: info
-          component: shopware or magento
-          contractId: qbcxvb
-          source: some.domain.name
-          message: Some useful message
-        version: "1"
       properties:
         version:
+          type: string
           description: The version parameter should always be 1.
           enum:
-          - "1"
-          type: string
+            - '1'
         messages:
           items:
             $ref: '#/components/schemas/LogMessage'
           type: array
     LogMessage:
-      example:
-        severity: info
-        component: shopware or magento
-        contractId: qbcxvb
-        source: some.domain.name
-        message: Some useful message
+      required:
+        - message
+        - severity
+        - source
+        - component
       properties:
         message:
+          type: string
           description: The information that needs to be published
           example: Some useful message
-          type: string
         severity:
-          description: Determines how severe is the information. The ENUM values are
-            listed in the descreasing order of their priority.<br> 1. trace - gives
-            more detailed information than any other level in the hierarchy<br> 2.
-            debug - helps developer to debug application and is generally useful for
-            providing support to the application developers<br> 3. info  - gives the
-            progress and chosen state information and is generally useful for end
-            user<br> 4. warn  - use of deprecated APIs, poor use of API, ‘almost’
-            errors, other runtime situations that are undesirable or unexpected, but
-            not necessarily “wrong”.<br> 5. error - gives information about a serious
-            error which needs to be addressed and may result in unstable state<br>
-            6. fatal - such errors result in premature termination and you don’t often
-            get this error<br>
-          enum:
-          - trace
-          - debug
-          - info
-          - warn
-          - error
-          - fatal
+          type: string
           example: info
-          type: string
+          description: Determines how severe is the information. The ENUM values are listed in the descreasing order of their priority.<br> 1. trace - gives more detailed information than any other level in the hierarchy<br> 2. debug - helps developer to debug application and is generally useful for providing support to the application developers<br> 3. info  - gives the progress and chosen state information and is generally useful for end user<br> 4. warn  - use of deprecated APIs, poor use of API, ‘almost’ errors, other runtime situations that are undesirable or unexpected, but not necessarily “wrong”.<br> 5. error - gives information about a serious error which needs to be addressed and may result in unstable state<br> 6. fatal - such errors result in premature termination and you don’t often get this error<br>
+          enum:
+            - trace
+            - debug
+            - info
+            - warn
+            - error
+            - fatal
         component:
-          description: The name of the integrated system.
+          type: string
           example: shopware or magento
-          type: string
+          description: The name of the integrated system.
         source:
-          description: Anything within the component that can be considered as an
-            entity to further categorize the log message.
-          example: some.domain.name
           type: string
+          example: some.domain.name
+          description: Anything within the component that can be considered as an entity to further categorize the log message.
         contractId:
+          type: string
           description: The ID of the contract
           example: qbcxvb
-          type: string
-      required:
-      - component
-      - message
-      - severity
-      - source
     GenericFilter:
-      description: This is a placeholder for filter expressions. They are using advanced
-        features and are not covered by openapi. If you need to use filter expressions
-        please contract us.
+      description: This is a placeholder for filter expressions. They are using advanced features and are not covered by openapi. If you need to use filter expressions please contract us.
       type: object
     PricingStrategy:
-      description: This is a placeholder for a pricing strategy. These are using advanced
-        features and are not covered by openapi. If you need to work with pricing
-        strategies please contract us.
+      description: This is a placeholder for a pricing strategy. These are using advanced features and are not covered by openapi. If you need to work with pricing strategies please contract us.
       type: object
     ScenarioTitle:
-      description: Title of the scenario strategy. Should not be empty and a maximum
-        of 50 chars is allowed
+      description: Title of the scenario strategy. Should not be empty and a maximum of 50 chars is allowed
       type: string
     ScenarioDescription:
       description: Description of the scenario strategy. Maximum of 1000 chars allowed
@@ -9188,13 +6711,6 @@ components:
       description: Version of the schema the scenario strategy is encoded in
       type: integer
     ApiContract:
-      example:
-        contractType: contractType
-        companyName: companyName
-        contractId: contractId
-        active: true
-        contractName: contractName
-        expirationDate: 2000-01-23T04:56:07.000+00:00
       properties:
         active:
           type: boolean
@@ -9211,9 +6727,6 @@ components:
           type: string
       type: object
     ApiError:
-      example:
-        code: code
-        message: message
       properties:
         code:
           type: string
@@ -9228,37 +6741,10 @@ components:
           type: array
       type: object
     EmptyApiResponse:
-      example:
-        data: '{}'
       properties:
         data:
           type: object
     ApiOffer:
-      example:
-        ignored: true
-        gtin: 6
-        productId: productId
-        retrievalDate: 2000-01-23T04:56:07.000+00:00
-        availability: true
-        creationDate: 2000-01-23T04:56:07.000+00:00
-        vendorName: vendorName
-        positionByTotalPrice: 2
-        productName: productName
-        url: url
-        minDeliveryTime: 5
-        vendorDomainId: vendorDomainId
-        deliveryCosts: 0.8008281904610115
-        maxDeliveryTime: 1
-        price: 7.061401241503109
-        domain: domain
-        contractId: contractId
-        attributes:
-        - name: name
-          value: value
-        - name: name
-          value: value
-        currency: currency
-        positionByUnitPrice: 5
       properties:
         attributes:
           items:
@@ -9308,31 +6794,18 @@ components:
         vendorName:
           type: string
       required:
-      - contractId
-      - creationDate
-      - currency
-      - deliveryCosts
-      - domain
-      - ignored
-      - price
-      - productId
-      - productName
-      - url
-      - vendorName
+        - productId
+        - domain
+        - price
+        - deliveryCosts
+        - productName
+        - vendorName
+        - creationDate
+        - currency
+        - contractId
+        - url
+        - ignored
     ApiProduct:
-      example:
-        customerProductId: customerProductId
-        gtin: 9
-        referencePrice: 4.145608029883936
-        maxPriceBoundary: 3.616076749251911
-        name: name
-        id: id
-        minPriceBoundary: 2.027123023002322
-        tags:
-        - value: value
-          key: key
-        - value: value
-          key: key
       properties:
         tags:
           items:
@@ -9357,24 +6830,12 @@ components:
           format: double
           type: number
       required:
-      - id
-      - name
-      - referencePrice
-      - tags
+        - id
+        - name
+        - referencePrice
+        - tags
       type: object
     PostProduct:
-      example:
-        customerProductId: customerProductId
-        gtin: 12345678910123
-        referencePrice: 19.99
-        maxPriceBoundary: 56.78
-        name: name
-        minPriceBoundary: 12.34
-        tags:
-        - value: value
-          key: key
-        - value: value
-          key: key
       properties:
         tags:
           items:
@@ -9384,63 +6845,54 @@ components:
           type: string
         gtin:
           description: Must not be negative
-          example: 12345678910123
           format: int64
           type: integer
+          example: 12345678910123
         minPriceBoundary:
-          description: Must not be less than 0.01. Must not be larger than maxPriceBoundary.
-            Will be rounded to the second decimal digit (half up)
+          description: Must not be less than 0.01. Must not be larger than maxPriceBoundary. Will be rounded to the second decimal digit (half up)
+          format: double
+          type: number
           example: 12.34
-          format: double
-          type: number
         maxPriceBoundary:
-          description: Must not be less than minPriceBoundary. Must not be larger
-            than 9,999,999,999,999.99. Will be rounded to the second decimal digit
-            (half up)
-          example: 56.78
+          description: Must not be less than minPriceBoundary. Must not be larger than 9,999,999,999,999.99. Will be rounded to the second decimal digit (half up)
           format: double
           type: number
+          example: 56.78
         name:
           description: Must not have more than 999 characters
           type: string
         referencePrice:
-          description: Must not be less than 0.01. Must not be larger than 9,999,999,999,999.99.
-            Will be rounded to the second decimal digit (half up)
-          example: 19.99
+          description: Must not be less than 0.01. Must not be larger than 9,999,999,999,999.99. Will be rounded to the second decimal digit (half up)
           format: double
           type: number
+          example: 19.99
       required:
-      - maxPriceBoundary
-      - minPriceBoundary
-      - name
-      - referencePrice
-      - tags
+        - name
+        - referencePrice
+        - tags
+        - minPriceBoundary
+        - maxPriceBoundary
       type: object
     Callbacks:
-      example:
-        pricemonitorCompleted:
-        - headers:
-            key: headers
-          bodyTemplate: bodyTemplate
-          method: method
-          name: name
-          url: url
-        - headers:
-            key: headers
-          bodyTemplate: bodyTemplate
-          method: method
-          name: name
-          url: url
       properties:
         pricemonitorCompleted:
           items:
-            $ref: '#/components/schemas/Callbacks_pricemonitorCompleted'
+            properties:
+              bodyTemplate:
+                type: string
+              headers:
+                additionalProperties:
+                  type: string
+              method:
+                type: string
+              name:
+                type: string
+              url:
+                type: string
+            type: object
           type: array
       type: object
     CreateCompanyResponse:
-      example:
-        name: name
-        id: 0
       properties:
         id:
           format: int64
@@ -9449,20 +6901,12 @@ components:
           type: string
       type: object
     DeletedItemsResponse:
-      example:
-        deleted: 0
       properties:
         deleted:
           description: Number of deleted orders
           type: integer
       type: object
     ExtendedTag:
-      example:
-        stringValue: stringValue
-        booleanValue: true
-        integerValue: 6
-        doubleValue: 0.8008281904610115
-        label: label
       properties:
         booleanValue:
           type: boolean
@@ -9477,55 +6921,35 @@ components:
         stringValue:
           type: string
       required:
-      - label
-      - stringValue
+        - label
+        - stringValue
     OfferFilterRequest:
       items:
         $ref: '#/components/schemas/AndOfferFilter'
       type: array
     ConstantOfferFilter:
-      example:
-        constant:
-          value: true
       properties:
         constant:
-          $ref: '#/components/schemas/ConstantOfferFilter_constant'
+          properties:
+            value:
+              type: boolean
+          type: object
     AndOfferFilter:
-      example:
-        and:
-          filters:
-          - constant:
-              value: true
-          - constant:
-              value: true
       properties:
         and:
-          $ref: '#/components/schemas/AndOfferFilter_and'
+          properties:
+            filters:
+              items:
+                $ref: '#/components/schemas/ConstantOfferFilter'
+              type: array
+          type: object
     OfferFilterApiResponse:
-      example:
-        data:
-        - and:
-            filters:
-            - constant:
-                value: true
-            - constant:
-                value: true
-        - and:
-            filters:
-            - constant:
-                value: true
-            - constant:
-                value: true
       properties:
         data:
           items:
             $ref: '#/components/schemas/AndOfferFilter'
           type: array
     PluginRegistration:
-      example:
-        metricsUrl: metricsUrl
-        pluginId: pluginId
-        shopSystem: shopSystem
       properties:
         pluginId:
           type: string
@@ -9534,44 +6958,24 @@ components:
         metricsUrl:
           type: string
     PluginRegistrationApiResponse:
-      example:
-        data:
-          metricsUrl: metricsUrl
-          pluginId: pluginId
-          shopSystem: shopSystem
       properties:
         data:
           $ref: '#/components/schemas/PluginRegistration'
+          type: object
     PluginRegistrationEmptyApiResponse:
-      example:
-        data: '{}'
       properties:
         data:
           type: object
     PutPluginRegistrationRequest:
       allOf:
-      - $ref: '#/components/schemas/PluginRegistration'
-      - $ref: '#/components/schemas/PutPluginRegistrationRequest_allOf'
+        - $ref: '#/components/schemas/PluginRegistration'
+        - type: object
+          properties:
+            version:
+              type: string
+              enum:
+                - '1'
     Feed:
-      example:
-        deltaUrl: deltaUrl
-        csvDecimalSeparator: csvDecimalSeparator
-        contractId: contractId
-        format: format
-        name: name
-        lastAccessed: 2000-01-23T04:56:07.000+00:00
-        csvSeparator: csvSeparator
-        id: id
-        lastDeletion: 2000-01-23T04:56:07.000+00:00
-        fields:
-        - default: default
-          name: name
-          label: label
-        - default: default
-          name: name
-          label: label
-        version: 0
-        url: url
       properties:
         contractId:
           type: string
@@ -9583,7 +6987,14 @@ components:
           type: string
         fields:
           items:
-            $ref: '#/components/schemas/Feed_fields'
+            properties:
+              default:
+                type: string
+              label:
+                type: string
+              name:
+                type: string
+            type: object
           type: array
         format:
           type: string
@@ -9605,98 +7016,64 @@ components:
       type: object
     GetOffersResponse:
       description: A collection of products
-      example:
-        next: next
-        total: 5
-        data:
-        - offers:
-          - availability: '{}'
-            creationDate: 2000-01-23T04:56:07.000+00:00
-            productName: productName
-            url: url
-            vendorIdOnDomain: vendorIdOnDomain
-            approved: true
-            minDeliveryTime: '{}'
-            deliveryCosts: 6.027456183070403
-            maxDeliveryTime: '{}'
-            price: 1.4658129805029452
-            vendor: vendor
-            domain: domain
-            attributes:
-            - value: value
-              key: key
-            - value: value
-              key: key
-          - availability: '{}'
-            creationDate: 2000-01-23T04:56:07.000+00:00
-            productName: productName
-            url: url
-            vendorIdOnDomain: vendorIdOnDomain
-            approved: true
-            minDeliveryTime: '{}'
-            deliveryCosts: 6.027456183070403
-            maxDeliveryTime: '{}'
-            price: 1.4658129805029452
-            vendor: vendor
-            domain: domain
-            attributes:
-            - value: value
-              key: key
-            - value: value
-              key: key
-          gtin: 0
-          productId: productId
-          tags:
-          - value: value
-            key: key
-          - value: value
-            key: key
-        - offers:
-          - availability: '{}'
-            creationDate: 2000-01-23T04:56:07.000+00:00
-            productName: productName
-            url: url
-            vendorIdOnDomain: vendorIdOnDomain
-            approved: true
-            minDeliveryTime: '{}'
-            deliveryCosts: 6.027456183070403
-            maxDeliveryTime: '{}'
-            price: 1.4658129805029452
-            vendor: vendor
-            domain: domain
-            attributes:
-            - value: value
-              key: key
-            - value: value
-              key: key
-          - availability: '{}'
-            creationDate: 2000-01-23T04:56:07.000+00:00
-            productName: productName
-            url: url
-            vendorIdOnDomain: vendorIdOnDomain
-            approved: true
-            minDeliveryTime: '{}'
-            deliveryCosts: 6.027456183070403
-            maxDeliveryTime: '{}'
-            price: 1.4658129805029452
-            vendor: vendor
-            domain: domain
-            attributes:
-            - value: value
-              key: key
-            - value: value
-              key: key
-          gtin: 0
-          productId: productId
-          tags:
-          - value: value
-            key: key
-          - value: value
-            key: key
       properties:
         data:
           items:
-            $ref: '#/components/schemas/GetOffersResponse_data'
+            description: The GTIN of a product and all of its offers
+            properties:
+              tags:
+                items:
+                  $ref: '#/components/schemas/Tag'
+                type: array
+              gtin:
+                format: int64
+                type: integer
+              offers:
+                items:
+                  description: An offer by a specific vendor for a certain product
+                  properties:
+                    approved:
+                      type: boolean
+                    attributes:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    availability:
+                      type: object
+                    creationDate:
+                      format: date-time
+                      type: string
+                    deliveryCosts:
+                      format: double
+                      type: number
+                    domain:
+                      type: string
+                    maxDeliveryTime:
+                      type: object
+                    minDeliveryTime:
+                      type: object
+                    price:
+                      format: double
+                      type: number
+                    productName:
+                      type: string
+                    url:
+                      type: string
+                    vendor:
+                      type: string
+                    vendorIdOnDomain:
+                      type: string
+                  type: object
+                type: array
+              productId:
+                description: Unique product identifier within pricemonitor
+                type: string
+            type: object
           type: array
         next:
           type: string
@@ -9705,43 +7082,38 @@ components:
           type: integer
       type: object
     GetPriceRecommendationsResponse:
-      example:
-        next: next
-        priceRecommendations:
-        - identifier: identifier
-          gtin: 6
-          recommendedPrice: 1.4658129805029452
-          currentPrice: 0.8008281904610115
-          currency: currency
-        - identifier: identifier
-          gtin: 6
-          recommendedPrice: 1.4658129805029452
-          currentPrice: 0.8008281904610115
-          currency: currency
       properties:
         next:
           type: string
         priceRecommendations:
           items:
-            $ref: '#/components/schemas/GetPriceRecommendationsResponse_priceRecommendations'
+            properties:
+              currency:
+                type: string
+              currentPrice:
+                format: double
+                type: number
+              gtin:
+                format: int64
+                type: integer
+              identifier:
+                type: string
+              recommendedPrice:
+                format: double
+                type: number
+            type: object
           type: array
       type: object
     OfferAttribute:
-      example:
-        name: name
-        value: value
       properties:
         name:
           type: string
         value:
           type: string
       required:
-      - name
-      - value
+        - name
+        - value
     Pagination:
-      example:
-        limit: 0
-        start: 6
       properties:
         limit:
           default: 100
@@ -9749,125 +7121,107 @@ components:
         start:
           type: integer
       required:
-      - start
+        - start
     OffersQuerySortOrderV30:
-      example:
-        metric: TotalPrice
-        order: asc
       properties:
         metric:
-          enum:
-          - TotalPrice
-          - Price
           type: string
+          enum:
+            - TotalPrice
+            - Price
         order:
-          enum:
-          - asc
           type: string
+          enum:
+            - asc
       required:
-      - metric
-      - order
+        - metric
+        - order
     PriceRecommendationQuerySortOrderV2:
-      example:
-        metric: productId
-        order: asc
       properties:
         metric:
-          enum:
-          - productId
-          - RelativePriceChangePercentage
           type: string
+          enum:
+            - productId
+            - RelativePriceChangePercentage
         order:
-          enum:
-          - asc
-          - desc
           type: string
+          enum:
+            - asc
+            - desc
       required:
-      - metric
-      - order
+        - metric
+        - order
     QueryProductsRequestV3:
-      example:
-        filter:
-          type: ComparisonFilter
-          left:
-            type: StringValueProvider
-            attributeName: productId
-          right:
-            type: SequenceOfStringConstantValueProvider
-            value:
-            - 1001
-            - 1002
-          comparison:
-            type: StringInSequence
-        pagination:
-          limit: 0
-          start: 6
       properties:
         filter:
           $ref: '#/components/schemas/ProductsFilter'
         pagination:
           $ref: '#/components/schemas/Pagination'
       required:
-      - pagination
+        - pagination
     PostOfferStatisticsRequest:
-      example:
-        filter:
-          type: ComparisonFilter
-          left:
-            type: StringValueProvider
-            attributeName: productId
-          right:
-            type: SequenceOfStringConstantValueProvider
-            value:
-            - 1001
-            - 1002
-          comparison:
-            type: StringInSequence
-        ownShopNames:
-          ebay.de:
-          - myAwesomeShop.de
-          - myAwesomeShop24.de
-          google.de:
-          - myAwesomeShop.de
-          - myAwesomeShop24.de
-        range:
-          start: 2018-04-04T13:46:13Z
-          end: 2018-04-06T13:46:13Z
-        includeDeliveryCosts: false
       properties:
         filter:
           $ref: '#/components/schemas/ProductsFilter'
         includeDeliveryCosts:
-          example: false
           type: boolean
+          example: false
         ownShopNames:
           additionalProperties:
-            example:
-            - myAwesomeShop.de
-            - myAwesomeShop24.de
             items:
               type: string
             type: array
-          description: Providing own shops names enables calculating shop positions.
-            The keys are domain names. The values are lists of shop names.
+            example:
+              - myAwesomeShop.de
+              - myAwesomeShop24.de
+          type: object
+          description: Providing own shops names enables calculating shop positions. The keys are domain names. The values are lists of shop names.
           example:
             ebay.de:
-            - myAwesomeShop.de
-            - myAwesomeShop24.de
+              - myAwesomeShop.de
+              - myAwesomeShop24.de
             google.de:
-            - myAwesomeShop.de
-            - myAwesomeShop24.de
-          type: object
+              - myAwesomeShop.de
+              - myAwesomeShop24.de
         range:
+          description: Time range of the offers included in the calculation
           $ref: '#/components/schemas/TimeRange'
       required:
-      - filter
-      - includeDeliveryCosts
-      - ownShopNames
-      - range
+        - range
+        - filter
+        - ownShopNames
+        - includeDeliveryCosts
     ProductsFilter:
-      description: Filter product statistics by a list of allowed internal pricemonitor
-        product ids
+      properties:
+        type:
+          type: string
+          enum:
+            - ComparisonFilter
+        left:
+          properties:
+            type:
+              type: string
+              enum:
+                - StringValueProvider
+            attributeName:
+              type: string
+              enum:
+                - productId
+        right:
+          properties:
+            type:
+              type: string
+              enum:
+                - SequenceOfStringConstantValueProvider
+            value:
+              items:
+                type: string
+              type: array
+              description: List of internal pricemonitor product ids
+        comparison:
+          type: string
+          enum:
+            - StringInSequence
       example:
         type: ComparisonFilter
         left:
@@ -9876,154 +7230,84 @@ components:
         right:
           type: SequenceOfStringConstantValueProvider
           value:
-          - 1001
-          - 1002
+            - 1001
+            - 1002
         comparison:
           type: StringInSequence
-      properties:
-        type:
-          enum:
-          - ComparisonFilter
-          type: string
-        left:
-          properties:
-            type:
-              enum:
-              - StringValueProvider
-              type: string
-            attributeName:
-              enum:
-              - productId
-              type: string
-        right:
-          properties:
-            type:
-              enum:
-              - SequenceOfStringConstantValueProvider
-              type: string
-            value:
-              description: List of internal pricemonitor product ids
-              items:
-                type: string
-              type: array
-        comparison:
-          enum:
-          - StringInSequence
-          type: string
+      description: Filter product statistics by a list of allowed internal pricemonitor product ids
       type: object
     PostOfferStatisticsApiResponse:
-      example:
-        data:
-        - productId: 1001
-          statsByDomain:
-            ebay.de:
-              offerCount: 4
-              minPrice: 16.0
-              averagePrice: 20.0
-              ownPosition:
-                price: 17.0
-                position: 2
-            google.de:
-              offerCount: 12
-              minPrice: 7.99
-              averagePrice: 10.0
-        - productId: 1002
-          statsByDomain:
-            ebay.de:
-              offerCount: 12
-              minPrice: 16.0
-              averagePrice: 20.0
-              ownPosition:
-                price: 17.0
-                position: 2
-            google.de:
-              offerCount: 4
-              minPrice: 7.99
-              averagePrice: 10.0
       properties:
         data:
-          example:
-          - productId: 1001
-            statsByDomain:
-              ebay.de:
-                offerCount: 4
-                minPrice: 16.0
-                averagePrice: 20.0
-                ownPosition:
-                  price: 17.0
-                  position: 2
-              google.de:
-                offerCount: 12
-                minPrice: 7.99
-                averagePrice: 10.0
-          - productId: 1002
-            statsByDomain:
-              ebay.de:
-                offerCount: 12
-                minPrice: 16.0
-                averagePrice: 20.0
-                ownPosition:
-                  price: 17.0
-                  position: 2
-              google.de:
-                offerCount: 4
-                minPrice: 7.99
-                averagePrice: 10.0
           items:
             $ref: '#/components/schemas/ProductOfferStatistics'
+            description: Contains offer statistics for each found product matching the provided filter
+          example:
+            - productId: 1001
+              statsByDomain:
+                ebay.de:
+                  offerCount: 4
+                  minPrice: 16
+                  averagePrice: 20
+                  ownPosition:
+                    price: 17
+                    position: 2
+                google.de:
+                  offerCount: 12
+                  minPrice: 7.99
+                  averagePrice: 10
+            - productId: 1002
+              statsByDomain:
+                ebay.de:
+                  offerCount: 12
+                  minPrice: 16
+                  averagePrice: 20
+                  ownPosition:
+                    price: 17
+                    position: 2
+                google.de:
+                  offerCount: 4
+                  minPrice: 7.99
+                  averagePrice: 10
           type: array
       type: object
     ProductOfferStatistics:
       properties:
         productId:
           description: The internal product id of the pricemonitor
-          example: "1001"
           type: string
+          example: 1001
         statsByDomain:
           additionalProperties:
             $ref: '#/components/schemas/OfferStatistics'
-          description: The offer statistics are grouped by domain.
           type: object
+          description: The offer statistics are grouped by domain.
       type: object
     OfferStatistics:
       properties:
         averagePrice:
-          description: The average price of the offers, always be provided with two
-            decimal places
-          example: 10.0
           format: double
           type: number
+          description: The average price of the offers, always be provided with two decimal places
+          example: 10
         minPrice:
-          description: The lowest price of the offers, always be provided with two
-            decimal places
-          example: 16.0
           format: double
           type: number
+          description: The lowest price of the offers, always be provided with two decimal places
+          example: 16
         offerCount:
+          type: integer
           description: The number of the found offers
           example: 4
-          type: integer
         ownPosition:
           $ref: '#/components/schemas/ShopRank'
       required:
-      - averagePrice
-      - minPrice
-      - offerCount
+        - averagePrice
+        - minPrice
+        - offerCount
       type: object
     Product:
       description: A product defined by its attributes
-      example:
-        gtin: 0
-        referencePrice: 5.962133916683182
-        maxPriceBoundary: 6.027456183070403
-        productId: productId
-        name: name
-        minPriceBoundary: 1.4658129805029452
-        tags:
-        - value: value
-          key: key
-        - value: value
-          key: key
       properties:
         tags:
           items:
@@ -10056,23 +7340,9 @@ components:
           $ref: '#/components/schemas/ApiProduct'
       type: object
     ProductOffersApiQuery:
-      example:
-        filter: '{}'
-        pagination:
-          limit: 0
-          start: 6
-        range:
-          start: 2018-04-04T13:46:13Z
-          end: 2018-04-06T13:46:13Z
-        sort:
-          metric: TotalPrice
-          order: asc
       properties:
         filter:
-          description: This is a placeholder for filter expressions. They are using
-            advanced features and are not covered by openapi. If you need to use filter
-            expressions please contract us.
-          type: object
+          $ref: '#/components/schemas/GenericFilter'
         pagination:
           $ref: '#/components/schemas/Pagination'
         range:
@@ -10080,26 +7350,12 @@ components:
         sort:
           $ref: '#/components/schemas/OffersQuerySortOrderV30'
       required:
-      - pagination
-      - range
+        - pagination
+        - range
     PriceRecommendationApiQueryV2:
-      example:
-        filter: '{}'
-        pagination:
-          limit: 0
-          start: 6
-        range:
-          start: 2018-04-04T13:46:13Z
-          end: 2018-04-06T13:46:13Z
-        sort:
-          metric: productId
-          order: asc
       properties:
         filter:
-          description: This is a placeholder for filter expressions. They are using
-            advanced features and are not covered by openapi. If you need to use filter
-            expressions please contract us.
-          type: object
+          $ref: '#/components/schemas/GenericFilter'
         pagination:
           $ref: '#/components/schemas/Pagination'
         range:
@@ -10107,111 +7363,87 @@ components:
         sort:
           $ref: '#/components/schemas/PriceRecommendationQuerySortOrderV2'
       required:
-      - pagination
-      - range
+        - pagination
+        - range
     ScenarioStrategyResponse:
-      description: Response body which contains the strategy scenario and relevant
-        metadata
-      example:
-        data:
-          updateDate: 2000-01-23T04:56:07.000+00:00
-          schemaVersion: 6
-          updatedBy: updatedBy
-          createdBy: createdBy
-          description: description
-          id: 0
-          title: title
-          strategy: '{}'
-          creationDate: 2000-01-23T04:56:07.000+00:00
+      description: Response body which contains the strategy scenario and relevant metadata
       properties:
         data:
-          $ref: '#/components/schemas/ScenarioStrategyResponse_data'
+          properties:
+            id:
+              type: integer
+              description: Id of the scenario strategy.
+            title:
+              $ref: '#/components/schemas/ScenarioTitle'
+            description:
+              $ref: '#/components/schemas/ScenarioDescription'
+            schemaVersion:
+              $ref: '#/components/schemas/ScenarioStrategySchemaVersion'
+            strategy:
+              $ref: '#/components/schemas/PricingStrategy'
+            creationDate:
+              type: string
+              format: date-time
+              description: Timestamp of creating the strategy scenario
+            createdBy:
+              type: string
+              description: Email address of the user who created the strategy scenario
+            updateDate:
+              type: string
+              format: date-time
+              description: Timestamp of the last update operation
+            updatedBy:
+              type: string
+              description: Email address of the user who last updated the strategy scenario
+          type: object
     PostScenarioStrategyRequest:
       description: Request body which contains the strategy and relevant metadata
-      example:
-        schemaVersion: 0
-        description: description
-        title: title
-        strategy: '{}'
       properties:
         title:
-          description: Title of the scenario strategy. Should not be empty and a maximum
-            of 50 chars is allowed
-          type: string
+          $ref: '#/components/schemas/ScenarioTitle'
         description:
-          description: Description of the scenario strategy. Maximum of 1000 chars
-            allowed
-          type: string
+          $ref: '#/components/schemas/ScenarioDescription'
         schemaVersion:
-          description: Version of the schema the scenario strategy is encoded in
-          type: integer
+          $ref: '#/components/schemas/ScenarioStrategySchemaVersion'
         strategy:
-          description: This is a placeholder for a pricing strategy. These are using
-            advanced features and are not covered by openapi. If you need to work
-            with pricing strategies please contract us.
-          type: object
+          $ref: '#/components/schemas/PricingStrategy'
       required:
-      - schemaVersion
-      - strategy
-      - title
+        - title
+        - schemaVersion
+        - strategy
       type: object
     PostOffersResponse:
       description: |
         Response body which contains Array of results in the same order as provided in the request body. Each item is an object that **either** includes **data** with value true, or **errors** with list of ApiError.
-      example:
-        data:
-        - data: true
-        - errors:
-          - code: string
-            message: string
       properties:
         data:
-          example:
-          - data: true
-          - errors:
-            - code: string
-              message: string
-          items:
-            $ref: '#/components/schemas/PostOffersResponse_data'
           type: array
+          items:
+            type: object
+            properties:
+              data:
+                type: boolean
+                example: true
+              errors:
+                items:
+                  $ref: '#/components/schemas/ApiError'
+                type: array
+          example:
+            - data: true
+            - errors:
+                - code: string
+                  message: string
       type: object
     DeleteProductsApiResponse:
-      example:
-        data:
-          deleted: 0
       properties:
         data:
-          $ref: '#/components/schemas/DeleteProductsApiResponse_data'
+          properties:
+            deleted:
+              type: integer
+              description: Number of deleted products
+          type: object
     PostProductsRequest:
       description: Request body which contains products
-      example:
-        identifyingAttributes:
-        - null
-        - null
-        version: "2"
-        products:
-        - customerProductId: customerProductId
-          gtin: 12345678910123
-          referencePrice: 19.99
-          maxPriceBoundary: 56.78
-          name: name
-          minPriceBoundary: 12.34
-          tags:
-          - value: value
-            key: key
-          - value: value
-            key: key
-        - customerProductId: customerProductId
-          gtin: 12345678910123
-          referencePrice: 19.99
-          maxPriceBoundary: 56.78
-          name: name
-          minPriceBoundary: 12.34
-          tags:
-          - value: value
-            key: key
-          - value: value
-            key: key
       properties:
         products:
           description: Products which should be added to the pricemonitor
@@ -10220,66 +7452,42 @@ components:
           type: array
         version:
           description: Version of the request body. Only version 2 is supported.
-          enum:
-          - "2"
           type: string
+          enum:
+            - '2'
         identifyingAttributes:
-          description: Non-empty list of product attributes which identify your products
-            uniquely
           items:
             $ref: '#/components/schemas/PostProductsIdentifyingAttribute'
           type: array
+          description: Non-empty list of product attributes which identify your products uniquely
       required:
-      - identifyingAttributes
-      - products
-      - version
+        - products
+        - version
+        - identifyingAttributes
       type: object
     PostProductsIdentifyingAttribute:
-      description: In addition to the enumerated values you can also use a product
-        tag. The identifying attribute needs to be filled for all products. The identifying
-        attribute needs to uniquely identify a product. If the identifying attribute
-        isn't unique, then only the last of the duplicates will be saved. For the
-        others duplicates an error will be provided
       enum:
-      - customerProductId
-      - gtin
-      - name
+        - customerProductId
+        - gtin
+        - name
       type: string
+      description: In addition to the enumerated values you can also use a product tag. The identifying attribute needs to be filled for all products. The identifying attribute needs to uniquely identify a product. If the identifying attribute isn't unique, then only the last of the duplicates will be saved. For the others duplicates an error will be provided
     BulkedPostProductsApiResponse:
-      example:
-        data:
-        - data:
-            productId: productId
-          errors:
-          - code: code
-            message: message
-          - code: code
-            message: message
-        - data:
-            productId: productId
-          errors:
-          - code: code
-            message: message
-          - code: code
-            message: message
       properties:
         data:
           items:
+            description: If the product could be added successfully, the corresponding pricemonitor product id is returned. Otherwise a dedicated api error is returned.
             $ref: '#/components/schemas/PostProductsApiResponse'
           type: array
       type: object
     PostProductsApiResponse:
-      example:
-        data:
-          productId: productId
-        errors:
-        - code: code
-          message: message
-        - code: code
-          message: message
       properties:
         data:
-          $ref: '#/components/schemas/PostProductsApiResponse_data'
+          properties:
+            productId:
+              type: string
+              description: The pricemonitor product id of the added product
+          type: object
         errors:
           items:
             $ref: '#/components/schemas/ApiError'
@@ -10288,37 +7496,30 @@ components:
     ShopRank:
       properties:
         position:
-          description: The position of own offer among competing offers
-          example: 2
           type: integer
+          example: 2
+          description: The position of own offer among competing offers
         price:
-          description: The price of own offer
-          example: 17.0
           format: double
           type: number
+          example: 17
+          description: The price of own offer
       required:
-      - position
-      - price
+        - position
+        - price
     TagInput:
-      example:
-        value: value
-        key: key
       properties:
         key:
-          description: Must not be an empty string. Must not have more than 100 characters.
-            All tags of one product need to have a unique key
+          description: Must not be an empty string. Must not have more than 100 characters. All tags of one product need to have a unique key
           type: string
         value:
           description: Must not have more than 10000 characters
           type: string
-      required:
-      - key
-      - value
       type: object
+      required:
+        - key
+        - value
     Tag:
-      example:
-        value: value
-        key: key
       properties:
         key:
           type: string
@@ -10326,9 +7527,6 @@ components:
           type: string
       type: object
     Task:
-      example:
-        id: id
-        url: url
       properties:
         id:
           type: string
@@ -10342,25 +7540,6 @@ components:
           type: string
       type: object
     TaskWithContractResourceApiResponse:
-      example:
-        taskType: taskType
-        failures:
-        - messageId: messageId
-          attributes:
-            key: '{}'
-        - messageId: messageId
-          attributes:
-            key: '{}'
-        data:
-        - data
-        - data
-        contractId: contractId
-        finishDate: 2000-01-23T04:56:07.000+00:00
-        state: state
-        creationDate: 2000-01-23T04:56:07.000+00:00
-        parentId: parentId
-        startDate: 2000-01-23T04:56:07.000+00:00
-        taskId: taskId
       properties:
         contractId:
           type: string
@@ -10373,7 +7552,13 @@ components:
           type: array
         failures:
           items:
-            $ref: '#/components/schemas/TaskWithContractResourceApiResponse_failures'
+            properties:
+              attributes:
+                additionalProperties:
+                  type: object
+              messageId:
+                type: string
+            type: object
           type: array
         finishDate:
           format: date-time
@@ -10391,28 +7576,21 @@ components:
           type: string
       type: object
     TimeRange:
-      example:
-        start: 2018-04-04T13:46:13Z
-        end: 2018-04-06T13:46:13Z
       properties:
         end:
+          format: date-time
+          type: string
           description: Timestamp of end of time range, formatted as ISO Date in UTC
-          example: 2018-04-06T13:46:13Z
-          format: date-time
-          type: string
+          example: '2018-04-06T13:46:13Z'
         start:
-          description: Timestamp of start of time range, formatted as ISO Date in
-            UTC
-          example: 2018-04-04T13:46:13Z
           format: date-time
           type: string
+          description: Timestamp of start of time range, formatted as ISO Date in UTC
+          example: '2018-04-04T13:46:13Z'
       required:
-      - end
-      - start
+        - start
+        - end
     UserSignupRequest:
-      example:
-        name: name
-        email: email
       properties:
         email:
           type: string
@@ -10420,90 +7598,79 @@ components:
           type: string
       type: object
     GenericTask:
-      description: A basic task type. Additional fields can be contained depending
-        on specific task type.
-      example:
-        result: '{}'
-        taskType: taskType
-        failures:
-        - '{}'
-        - '{}'
-        failureCode: failureCode
-        data: '{}'
-        finishDate: 2000-01-23T04:56:07.000+00:00
-        state: pending
-        creationDate: 2000-01-23T04:56:07.000+00:00
-        startDate: 2000-01-23T04:56:07.000+00:00
-        taskId: taskId
-        parentId: parentId
+      description: A basic task type. Additional fields can be contained depending on specific task type.
       properties:
         creationDate:
+          type: string
+          format: date-time
           description: The creation date of this task
-          format: date-time
-          type: string
         startDate:
+          type: string
+          format: date-time
           description: The timestamp of when processing of this task was started
-          format: date-time
-          type: string
         finishDate:
-          description: The timestamp of when processing of this task finished
+          type: string
           format: date-time
-          type: string
+          description: The timestamp of when processing of this task finished
         state:
-          description: The current processing state of this task
-          enum:
-          - pending
-          - executing
-          - succeeded
-          - failed
           type: string
+          enum:
+            - pending
+            - executing
+            - succeeded
+            - failed
+          description: The current processing state of this task
         failures:
-          description: Schemaless. If any errors occured during processing, these
-            will be contained here.
+          type: array
           items:
             type: object
-          type: array
+          description: Schemaless. If any errors occured during processing, these will be contained here.
         taskId:
+          type: string
           description: The unique ID of this task
-          type: string
         parentId:
+          type: string
           description: The parents unique taskId, if any parent exists
-          type: string
         taskType:
+          type: string
           description: The identifier string for the type of task
-          type: string
         data:
-          description: Schemaless. Contains the payload of the task given during task
-            creation.
           type: object
+          description: Schemaless. Contains the payload of the task given during task creation.
         result:
-          description: Schemaless. Contains the processing result for this task. Type
-            is dependent on task type.
           type: object
+          description: Schemaless. Contains the processing result for this task. Type is dependent on task type.
         failureCode:
-          description: If any error occured the error code for this error will be
-            contained here.
           type: string
+          description: If any error occured the error code for this error will be contained here.
       required:
-      - creationDate
-      - state
-      - taskId
-      - taskType
+        - creationDate
+        - state
+        - taskId
+        - taskType
     GenericTaskWithUrl:
       allOf:
-      - $ref: '#/components/schemas/GenericTask'
-      - $ref: '#/components/schemas/GenericTaskWithUrl_allOf'
+        - $ref: '#/components/schemas/GenericTask'
+        - type: object
+          description: A basic task type containing the URL. Additional fields can be contained depending on specific task type.
+          properties:
+            url:
+              type: string
+              description: The URL of the task
+          required:
+            - url
     UpdateTaskRequestV2:
       allOf:
-      - $ref: '#/components/schemas/GenericTask'
-      - $ref: '#/components/schemas/UpdateTaskRequestV2_allOf'
+        - $ref: '#/components/schemas/GenericTask'
+        - type: object
+          properties:
+            contractId:
+              type: string
+              description: The contract SID to update the task for
+          required:
+            - contractId
     NewUser:
       description: New user
-      example:
-        password: password
-        companyId: 0
-        name: name
-        email: email
       properties:
         email:
           type: string
@@ -10514,520 +7681,509 @@ components:
         companyId:
           type: integer
       required:
-      - email
-      - name
-    GetPricingStrategyHistoryApiResponse:
+        - email
+        - name
+    com.patagona.pricemonitor.share.api.StrategyMetadataResponseV3:
+      description: Metadata used for strategy versioning.
+      properties:
+        documentVersion:
+          type: integer
+          description: strategy version per contract
+        documentVersionMessage:
+          type: string
+          description: message provided by user when saving new strategy
+        version:
+          type: string
+          description: schema version of the strategy
+        updateDate:
+          type: string
+          format: date-time
+          description: timestamp of last strategy update. It needs to be an option to ensure old strategies can be read.
+        updatedBy:
+          type: string
+          description: user email of the account that updated the strategy. It needs to be an option to ensure old strategies can be read.
       additionalProperties: false
-      example:
-        data:
-          history:
-          - documentVersionMessage: documentVersionMessage
-            updateDate: 2000-01-23T04:56:07.000+00:00
-            updatedBy: updatedBy
-            version: version
-            documentVersion: 0
-          - documentVersionMessage: documentVersionMessage
-            updateDate: 2000-01-23T04:56:07.000+00:00
-            updatedBy: updatedBy
-            version: version
-            documentVersion: 0
+      type: object
+      required:
+        - documentVersion
+        - version
+    com.patagona.pricemonitor.share.api.GetPricingStrategyHistoryResponse:
+      description: Version history of all strategies
+      properties:
+        history:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.StrategyMetadataResponseV3'
+          description: contains metadata of all strategies
+      additionalProperties: false
+      type: object
+      required:
+        - history
+    GetPricingStrategyHistoryApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
       properties:
         data:
           $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.GetPricingStrategyHistoryResponse'
-      required:
-      - data
-      type: object
-    ScenarioStrategyMetadataResponseApiResponse:
+    com.patagona.pricemonitor.share.api.ScenarioStrategyMetadataResponse:
+      description: Metadata of a scenario strategy in an API response. Here the createdBy/updatedBy fields are e-mails, in [[com.patagona.pricemonitor.share.strategies.ScenarioStrategyMetadata]] these refer to ids
+      properties:
+        description:
+          type: string
+          description: optional description of the scenario
+        id:
+          type: number
+          description: unique identifier of the strategy scenario
+        updateDate:
+          type: string
+          format: date-time
+          description: timestamp of last strategy update
+        createdBy:
+          type: string
+          description: e-mail of the user creating the strategy
+        creationDate:
+          type: string
+          format: date-time
+          description: timestamp of when the strategy was created
+        title:
+          type: string
+          description: up to 50 characters, has to be unique for one contract
+        schemaVersion:
+          type: integer
+          description: schema version of the strategy
+        updatedBy:
+          type: string
+          description: e-mail of the user that last updated the strategy
       additionalProperties: false
-      example:
-        data:
-        - updateDate: 2000-01-23T04:56:07.000+00:00
-          schemaVersion: 6
-          updatedBy: updatedBy
-          createdBy: createdBy
-          description: description
-          id: 0.8008281904610115
-          creationDate: 2000-01-23T04:56:07.000+00:00
-          title: title
-        - updateDate: 2000-01-23T04:56:07.000+00:00
-          schemaVersion: 6
-          updatedBy: updatedBy
-          createdBy: createdBy
-          description: description
-          id: 0.8008281904610115
-          creationDate: 2000-01-23T04:56:07.000+00:00
-          title: title
+      type: object
+      required:
+        - updateDate
+        - updatedBy
+        - id
+        - createdBy
+        - schemaVersion
+        - creationDate
+        - title
+    ScenarioStrategyMetadataResponseApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
       properties:
         data:
           items:
             $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ScenarioStrategyMetadataResponse'
           type: array
-      required:
-      - data
-      type: object
-    PostScenarioStrategyResponseApiResponse:
+    com.patagona.pricemonitor.share.api.PostScenarioStrategyResponse:
+      description: Response of a successful post request
+      properties:
+        id:
+          type: number
+          description: unique identifier of the strategy scenario
       additionalProperties: false
-      example:
-        data:
-          id: 0.8008281904610115
+      type: object
+      required:
+        - id
+    PostScenarioStrategyResponseApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
       properties:
         data:
           $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostScenarioStrategyResponse'
-      required:
-      - data
-      type: object
-    GetAllDomainsV3ApiResponse:
+    com.patagona.pricemonitor.share.api.GetAllDomainsV3:
+      description: Response body containing domain data
+      properties:
+        domains:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              domain:
+                type: string
+                description: domain url
+              domainId:
+                type: number
+                description: internal domain id
+              offerSources:
+                type: array
+                items:
+                  type: string
+                uniqueItems: true
+                description: 'list of offerSources for the domain OfferSource:  Describes the origin of the offers. Domain may have more than one offer sources. Here are the possible offer sources: DEFAULT_MONITORING Offers - which are gathered via the monitoring-pipeline by a standard product search. This is typically done via GTIN. CUSTOM_MONITORING Offers - which are gathered via the monitoring-pipeline by a customized search. For instance via tags. OMNIA_CUSTOM_SPIDERING Offers - which originate from omnia custom spidering sources. The domain needs to be prefixed with "omnia.custom.spidering.". PUSH_API Offers - which originate from services where we have a direct API connection and get informed about offer changes. Example: Offers from Amazon-Repricer OTHER Offers - which originate from other sources e.g. Scripts which publish offers'
+              name:
+                type: string
+                description: display name for the domain
+            required:
+              - domain
+              - domainId
+              - offerSources
+              - name
+          description: Sequence of domain data
       additionalProperties: false
-      example:
-        data:
-          domains:
-          - domain: domain
-            name: name
-            domainId: 0.8008281904610115
-            offerSources:
-            - offerSources
-            - offerSources
-          - domain: domain
-            name: name
-            domainId: 0.8008281904610115
-            offerSources:
-            - offerSources
-            - offerSources
+      type: object
+      required:
+        - domains
+    GetAllDomainsV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
       properties:
         data:
           $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.GetAllDomainsV3'
-      required:
-      - data
-      type: object
     com.patagona.pricemonitor.share.api.PostAdminAddDomainBodyV3:
-      additionalProperties: false
       description: Request body that contains information about adding a new domain
       properties:
         domain:
-          description: 'the domain being added. (Must be unique and non-empty) Allowed
-            domain pattern: "<domain-name>.<top-level-domain>". Example:"google.com",
-            "amazon.co.uk" (valid), "_google_com" (invalid). For omnia custom monitoring,
-            the domain name must be prefixed with "omnia.custom.spidering."'
           type: string
+          description: 'the domain being added. (Must be unique and non-empty) Allowed domain pattern: "<domain-name>.<top-level-domain>". Example:"google.com", "amazon.co.uk" (valid), "_google_com" (invalid). For omnia custom monitoring, the domain name must be prefixed with "omnia.custom.spidering."'
         name:
-          description: display name for the domain in the UI. (Must be unique and
-            non-empty)
           type: string
+          description: display name for the domain in the UI. (Must be unique and non-empty)
         offerSources:
-          description: 'sources of offers on this domain. (Must be non-empty) Allowed
-            sources: "DEFAULT_MONITORING", "CUSTOM_MONITORING", "OMNIA_CUSTOM_SPIDERING",
-            "PUSH_API", "OTHER" @example domain = "google.de", offerSources = Set("DEFAULT_MONITORING")'
+          type: array
           items:
             type: string
-          type: array
           uniqueItems: true
-      required:
-      - domain
-      - name
-      - offerSources
-      type: object
-    PostAdminAddDomainV3ApiResponse:
+          description: 'sources of offers on this domain. (Must be non-empty) Allowed sources: "DEFAULT_MONITORING", "CUSTOM_MONITORING", "OMNIA_CUSTOM_SPIDERING", "PUSH_API", "OTHER" @example domain = "google.de", offerSources = Set("DEFAULT_MONITORING")'
       additionalProperties: false
-      example:
-        data:
-          domainId: 0.8008281904610115
+      type: object
+      required:
+        - domain
+        - name
+        - offerSources
+    com.patagona.pricemonitor.share.api.PostAdminAddDomainV3:
+      description: Response body containing id for the added domain
+      properties:
+        domainId:
+          type: number
+          description: domain id
+      additionalProperties: false
+      type: object
+      required:
+        - domainId
+    PostAdminAddDomainV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
       properties:
         data:
           $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostAdminAddDomainV3'
-      required:
-      - data
-      type: object
-    VersionApiResponse:
+    com.patagona.pricemonitor.share.api.ApplicationVersion:
+      description: Current api version.
+      properties:
+        version:
+          type: string
+          description: version represented as X.Y.Z
       additionalProperties: false
-      example:
-        data:
-          version: version
+      type: object
+      required:
+        - version
+    VersionApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
       properties:
         data:
           $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApplicationVersion'
-      required:
-      - data
-      type: object
     CreateCompanyApiResponse:
+      required:
+        - data
+      type: object
       additionalProperties: false
-      example:
-        data:
-          name: name
-          id: 0
+      description: ''
       properties:
         data:
           $ref: '#/components/schemas/CreateCompanyResponse'
-      required:
-      - data
-      type: object
     GetCompanyContractsApiResponse:
+      required:
+        - data
+      type: object
       additionalProperties: false
-      example:
-        data:
-        - contractType: contractType
-          companyName: companyName
-          contractId: contractId
-          active: true
-          contractName: contractName
-          expirationDate: 2000-01-23T04:56:07.000+00:00
-        - contractType: contractType
-          companyName: companyName
-          contractId: contractId
-          active: true
-          contractName: contractName
-          expirationDate: 2000-01-23T04:56:07.000+00:00
+      description: ''
       properties:
         data:
           items:
             $ref: '#/components/schemas/ApiContract'
           type: array
-      required:
-      - data
-      type: object
     com.patagona.pricemonitor.share.api.CreateContractRequest:
-      additionalProperties: false
       description: Represents a new contract.
       properties:
         contractType:
-          description: 'Type of the contract. Currently, only 2 types are supported:
-            - Pricemonitor for manufacturers - Pricemonitor for resellers'
           type: string
+          description: 'Type of the contract. Currently, only 2 types are supported: - Pricemonitor for manufacturers - Pricemonitor for resellers'
         contractName:
+          type: string
           description: Name of the new contract
-          type: string
         expirationDate:
-          description: Expiration date
-          format: date-time
           type: string
-      required:
-      - contractName
-      - contractType
-      type: object
-    AddCompanyContractApiResponse:
+          format: date-time
+          description: Expiration date
       additionalProperties: false
-      example:
-        data:
-          contractType: contractType
-          companyName: companyName
-          contractId: contractId
-          active: true
-          contractName: contractName
-          expirationDate: 2000-01-23T04:56:07.000+00:00
+      type: object
+      required:
+        - contractType
+        - contractName
+    AddCompanyContractApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
       properties:
         data:
           $ref: '#/components/schemas/ApiContract'
-      required:
-      - data
-      type: object
-    com.patagona.pricemonitor.share.api.PostCustomerOrdersRequestV2:
+    com.patagona.pricemonitor.share.api.CustomerOrderItemV2:
+      description: A ordered item
+      properties:
+        itemId:
+          type: string
+          description: Id of the item in the customer's system. It is expected to be the customerProductId. It should be guaranteed that the itemId can be always assigned to only one product or variant.
+        unitPrice:
+          type: number
+          description: Unit price of an item
+        quantity:
+          type: integer
+          description: How often the item was purchased
+        taxPercentage:
+          type: number
+          description: Tax percentage applied on unit price, e.g. 20 for 20% tax
       additionalProperties: false
+      type: object
+      required:
+        - itemId
+        - unitPrice
+        - quantity
+    com.patagona.pricemonitor.share.api.CustomerOrderProductMappingV2:
+      description: We originally planned to support complex mappings, but for sake of maintainability we restrict the mappings to itemId-> (customerProductId or productId)
+      properties:
+        source:
+          type: string
+          description: Identifier field within item. Only valid value is 'itemId'
+        target:
+          type: string
+          description: Must be 'customerProductId' or 'productId' since plugins are still publishing both values. The semantics are actually the same. In both cases they address the customerProductId.
+      additionalProperties: false
+      type: object
+      required:
+        - source
+        - target
+    com.patagona.pricemonitor.share.api.CustomerOrderV2:
+      description: An order placed in a shop.
+      properties:
+        shippingCosts:
+          type: number
+          description: Shipping costs of the order
+        orderId:
+          type: string
+          description: Unique id of an order. It must mean unique in the shop, not in the pricemonitor.
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CustomerOrderItemV2'
+          description: List of bought items
+        totalPrice:
+          type: number
+          description: Total price of the order
+        productMappings:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CustomerOrderProductMappingV2'
+          description: A relation from the products in your system to the pricemonitor. Currently it must contain exactly one element.
+        origin:
+          type: string
+          description: Origin of an order, e.g. the online shop were the order is placed
+        creationDate:
+          type: string
+          format: date-time
+          description: Date when the order is created in UTC
+        currency:
+          type: string
+          description: 'Currency used in the order. ISO 4217 Currency Codes: e.g. EUR'
+        referrer:
+          type: string
+          description: Referrer of an order. Third party (e.g. marketplace) which referred the customer to the online shop
+      additionalProperties: false
+      type: object
+      required:
+        - orderId
+        - shippingCosts
+        - origin
+        - creationDate
+        - items
+        - productMappings
+        - totalPrice
+        - currency
+    com.patagona.pricemonitor.share.api.PostCustomerOrdersRequestV2:
       description: Request body containing bulked orders
       properties:
         orders:
-          description: Orders in bulk
+          type: array
           items:
             $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CustomerOrderV2'
-          type: array
+          description: Orders in bulk
         version:
+          type: string
           description: Version of orders
-          type: string
-      required:
-      - orders
-      - version
-      type: object
-    com.patagona.pricemonitor.share.api.CustomerOrderV2:
       additionalProperties: false
-      description: An order placed in a shop.
-      example:
-        referrer: referrer
-        productMappings:
-        - source: source
-          target: target
-        - source: source
-          target: target
-        orderId: orderId
-        totalPrice: 5.637376656633329
-        origin: origin
-        currency: currency
-        creationDate: 2000-01-23T04:56:07.000+00:00
-        items:
-        - unitPrice: 6.027456183070403
-          itemId: itemId
-          quantity: 1
-          taxPercentage: 5.962133916683182
-        - unitPrice: 6.027456183070403
-          itemId: itemId
-          quantity: 1
-          taxPercentage: 5.962133916683182
-        shippingCosts: 0.8008281904610115
-      properties:
-        shippingCosts:
-          description: Shipping costs of the order
-          type: number
-        orderId:
-          description: Unique id of an order. It must mean unique in the shop, not
-            in the pricemonitor.
-          type: string
-        items:
-          description: List of bought items
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CustomerOrderItemV2'
-          type: array
-        totalPrice:
-          description: Total price of the order
-          type: number
-        productMappings:
-          description: A relation from the products in your system to the pricemonitor.
-            Currently it must contain exactly one element.
-          items:
-            $ref: '#/components/schemas/com_patagona_pricemonitor_share_api_CustomerOrderV2_productMappings'
-          type: array
-        origin:
-          description: Origin of an order, e.g. the online shop were the order is
-            placed
-          type: string
-        creationDate:
-          description: Date when the order is created in UTC
-          format: date-time
-          type: string
-        currency:
-          description: 'Currency used in the order. ISO 4217 Currency Codes: e.g.
-            EUR'
-          type: string
-        referrer:
-          description: Referrer of an order. Third party (e.g. marketplace) which
-            referred the customer to the online shop
-          type: string
-      required:
-      - creationDate
-      - currency
-      - items
-      - orderId
-      - origin
-      - productMappings
-      - shippingCosts
-      - totalPrice
       type: object
-    com.patagona.pricemonitor.share.api.CustomerOrderItemV2:
-      additionalProperties: false
-      description: A ordered item
-      example:
-        unitPrice: 6.027456183070403
-        itemId: itemId
-        quantity: 1
-        taxPercentage: 5.962133916683182
-      properties:
-        itemId:
-          description: Id of the item in the customer's system. It is expected to
-            be the customerProductId. It should be guaranteed that the itemId can
-            be always assigned to only one product or variant.
-          type: string
-        unitPrice:
-          description: Unit price of an item
-          type: number
-        quantity:
-          description: How often the item was purchased
-          type: integer
-        taxPercentage:
-          description: Tax percentage applied on unit price, e.g. 20 for 20% tax
-          type: number
       required:
-      - itemId
-      - quantity
-      - unitPrice
-      type: object
+        - orders
+        - version
     PostOrdersBulkApiResponse:
-      example:
-        data:
-        - data:
-            orders:
-            - referrer: referrer
-              productMappings:
-              - source: source
-                target: target
-              - source: source
-                target: target
-              orderId: orderId
-              totalPrice: 5.637376656633329
-              origin: origin
-              currency: currency
-              creationDate: 2000-01-23T04:56:07.000+00:00
-              items:
-              - unitPrice: 6.027456183070403
-                itemId: itemId
-                quantity: 1
-                taxPercentage: 5.962133916683182
-              - unitPrice: 6.027456183070403
-                itemId: itemId
-                quantity: 1
-                taxPercentage: 5.962133916683182
-              shippingCosts: 0.8008281904610115
-            - referrer: referrer
-              productMappings:
-              - source: source
-                target: target
-              - source: source
-                target: target
-              orderId: orderId
-              totalPrice: 5.637376656633329
-              origin: origin
-              currency: currency
-              creationDate: 2000-01-23T04:56:07.000+00:00
-              items:
-              - unitPrice: 6.027456183070403
-                itemId: itemId
-                quantity: 1
-                taxPercentage: 5.962133916683182
-              - unitPrice: 6.027456183070403
-                itemId: itemId
-                quantity: 1
-                taxPercentage: 5.962133916683182
-              shippingCosts: 0.8008281904610115
-            version: version
-          errors:
-          - code: code
-            message: message
-          - code: code
-            message: message
-        - data:
-            orders:
-            - referrer: referrer
-              productMappings:
-              - source: source
-                target: target
-              - source: source
-                target: target
-              orderId: orderId
-              totalPrice: 5.637376656633329
-              origin: origin
-              currency: currency
-              creationDate: 2000-01-23T04:56:07.000+00:00
-              items:
-              - unitPrice: 6.027456183070403
-                itemId: itemId
-                quantity: 1
-                taxPercentage: 5.962133916683182
-              - unitPrice: 6.027456183070403
-                itemId: itemId
-                quantity: 1
-                taxPercentage: 5.962133916683182
-              shippingCosts: 0.8008281904610115
-            - referrer: referrer
-              productMappings:
-              - source: source
-                target: target
-              - source: source
-                target: target
-              orderId: orderId
-              totalPrice: 5.637376656633329
-              origin: origin
-              currency: currency
-              creationDate: 2000-01-23T04:56:07.000+00:00
-              items:
-              - unitPrice: 6.027456183070403
-                itemId: itemId
-                quantity: 1
-                taxPercentage: 5.962133916683182
-              - unitPrice: 6.027456183070403
-                itemId: itemId
-                quantity: 1
-                taxPercentage: 5.962133916683182
-              shippingCosts: 0.8008281904610115
-            version: version
-          errors:
-          - code: code
-            message: message
-          - code: code
-            message: message
+      type: object
       properties:
         data:
-          items:
-            $ref: '#/components/schemas/PostOrdersBulkApiResponse_data_1'
           type: array
-      type: object
-    GetPriceRecommendationApiResponse:
+          items:
+            type: object
+            properties:
+              data:
+                properties:
+                  orders:
+                    items:
+                      $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CustomerOrderV2'
+                    type: array
+                  version:
+                    type: string
+                type: object
+              errors:
+                items:
+                  $ref: '#/components/schemas/ApiError'
+                type: array
+    com.patagona.pricemonitor.share.api.ExtendedTag:
+      description: 'Tags represent additional information of a product. Extended tags can contain evaluated values like numbers which are determined during product import. The `stringValue` is used for deriving the evaluated values. Example: You provide a tag with label "strategy" and `stringValue` "1" during product import. This will be evaluated to these extended values: - integerValue  1 - doubleValue   1.0 - booleanValue  true'
+      properties:
+        doubleValue:
+          type: number
+          description: The double value depends on the decimal separator which has been provided during product import.
+        integerValue:
+          type: integer
+          description: The integer value of the tag. It's only defined when the `stringValue` consists solely of digits.
+        label:
+          type: string
+          description: The name of the tag. It can't be empty.
+        stringValue:
+          type: string
+          description: The text value of the tag.
+        booleanValue:
+          type: boolean
+          description: The boolean value of the tag. It's only set to true when the `stringValue` is "1" or "true".
       additionalProperties: false
-      example:
-        data:
-        - relativePriceChangePercentage: 3.616076749251911
-          customerProductId: customerProductId
-          gtin: 9.301444243932576
-          productId: productId
-          originalTags:
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          oldPrice: 0.8008281904610115
-          tags:
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          originalMaxPriceBoundary: 4.145608029883936
-          newPosition: 2
-          originalMinPriceBoundary: 7.386281948385884
-          oldDeliveryCosts: 1.4658129805029452
-          deliveryCosts: 6.027456183070403
-          price: 2.3021358869347655
-          relevantDomain: relevantDomain
-          currency: currency
-          oldPosition: 7
-          timestamp: 2000-01-23T04:56:07.000+00:00
-        - relativePriceChangePercentage: 3.616076749251911
-          customerProductId: customerProductId
-          gtin: 9.301444243932576
-          productId: productId
-          originalTags:
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          oldPrice: 0.8008281904610115
-          tags:
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          originalMaxPriceBoundary: 4.145608029883936
-          newPosition: 2
-          originalMinPriceBoundary: 7.386281948385884
-          oldDeliveryCosts: 1.4658129805029452
-          deliveryCosts: 6.027456183070403
-          price: 2.3021358869347655
-          relevantDomain: relevantDomain
-          currency: currency
-          oldPosition: 7
-          timestamp: 2000-01-23T04:56:07.000+00:00
-        meta:
-          totalSize: 1
-          start: 1
-          limit: 1
-          nextUrl: nextUrl
+      type: object
+      required:
+        - stringValue
+        - label
+    com.patagona.pricemonitor.share.api.ApiPriceRecommendation:
+      description: Represents a price recommendation of the pricemonitor.
+      properties:
+        oldPrice:
+          type: number
+          description: The price of the cheapest offer of the own shop(s) on the relevant domain
+        deliveryCosts:
+          type: number
+          description: The delivery costs which were considered for the recommended price
+        timestamp:
+          type: string
+          format: date-time
+          description: The timestamp when the price recommendation has been calculated
+        oldDeliveryCosts:
+          type: number
+          description: The delivery costs corresponding to `oldPrice`
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ExtendedTag'
+          description: Additional information on this product
+        price:
+          type: number
+          description: The recommended price of the relevant domain
+        oldPosition:
+          type: integer
+          description: The old position on the relevant domain
+        gtin:
+          type: number
+          description: GTIN of the product
+        relativePriceChangePercentage:
+          type: number
+          description: Absolute percentage how the recommended price changed compared to the `oldPrice` e.g. 200 stands for 200% which means the recommended price has doubled
+        newPosition:
+          type: integer
+          description: The new position on the relevant domain
+        customerProductId:
+          type: string
+          description: The customer's id of the product
+        originalMaxPriceBoundary:
+          type: number
+          description: Max price boundary during the time when the price was calculated
+        relevantDomain:
+          type: string
+          description: The decisive domain of the price recommendation. It's been determined by the cheapest price recommendation.
+        originalMinPriceBoundary:
+          type: number
+          description: Min price boundary during the time when the price was calculated
+        currency:
+          type: string
+          description: The currency of the price recommendation.
+        productId:
+          type: string
+          description: The internal product id of the pricemonitor
+        originalTags:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ExtendedTag'
+          description: 'List of tags which were set during the time when the price has been calculated. ATTENTION: These are historic tags which are maybe outdated or incomplete.'
+      additionalProperties: false
+      type: object
+      required:
+        - tags
+        - productId
+        - price
+        - timestamp
+        - originalMinPriceBoundary
+        - originalTags
+        - originalMaxPriceBoundary
+        - currency
+    com.patagona.pricemonitor.share.api.PaginationResponse:
+      description: This model describes the information passed to the user for a paginated request.
+      properties:
+        nextUrl:
+          type: string
+          description: the url that can be called to retrieve the next page, None if th last page has been requested
+        totalSize:
+          type: integer
+          description: the total number of elements that is paginated over
+        start:
+          type: integer
+          description: the start index of the currently requested page
+        limit:
+          type: integer
+          description: the number of elements in a full page
+      additionalProperties: false
+      type: object
+      required:
+        - totalSize
+        - start
+        - limit
+    GetPriceRecommendationApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
       properties:
         data:
           items:
@@ -11035,3040 +8191,183 @@ components:
           type: array
         meta:
           $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PaginationResponse'
-      required:
-      - data
-      type: object
-    com.patagona.pricemonitor.share.api.CreateTaskBodyV2:
+    org.json4s.JValue:
+      properties: {}
       additionalProperties: false
+      type: object
+      required: []
+    com.patagona.pricemonitor.share.api.CreateTaskBodyV2:
       description: Definition of a task to be created.
       properties:
         taskType:
-          description: The type of the task to be created. Can be any of [alert, backend.tasks.pricemonitor.offers.monitoring,
-            backend.tasks.pricemonitor.offers.preprocessing, backend.tasks.pricemonitor.callback]
           type: string
+          description: The type of the task to be created. Can be any of [alert, backend.tasks.pricemonitor.offers.monitoring, backend.tasks.pricemonitor.offers.preprocessing, backend.tasks.pricemonitor.callback]
         data:
-          additionalProperties: false
-          properties: {}
-          type: object
+          $ref: '#/components/schemas/org.json4s.JValue'
+          description: The task definition. Schema dependent on the actual task type.
         triggerFollowUpTask:
-          description: optional flag to specify whether or not to trigger the next
-            task. Currently only integrated to trigger callbacks after preprocessing
           type: boolean
+          description: optional flag to specify whether or not to trigger the next task. Currently only integrated to trigger callbacks after preprocessing
         includeForBilling:
-          description: optional flag to specify whether or not to include the task
-            in billing. This is especially useful when manual monitoring is triggered
-            by our admins
           type: boolean
-      required:
-      - taskType
-      type: object
-    org.json4s.JValue:
+          description: optional flag to specify whether or not to include the task in billing. This is especially useful when manual monitoring is triggered by our admins
       additionalProperties: false
-      properties: {}
       type: object
-    com.patagona.pricemonitor.share.api.UserInfo:
-      additionalProperties: false
-      description: This case class is used for serializing user-information for the
-        account-endpoints
-      example:
-        companies:
-        - name: name
-          id: 0.8008281904610115
-          contracts:
-          - name: name
-            active: true
-            id: 6.027456183070403
-            type: type
-            sid: sid
-          - name: name
-            active: true
-            id: 6.027456183070403
-            type: type
-            sid: sid
-        - name: name
-          id: 0.8008281904610115
-          contracts:
-          - name: name
-            active: true
-            id: 6.027456183070403
-            type: type
-            sid: sid
-          - name: name
-            active: true
-            id: 6.027456183070403
-            type: type
-            sid: sid
-        roles:
-        - roles
-        - roles
-        name: name
-        lastActiveDate: lastActiveDate
-        id: 1.4658129805029452
-        email: email
-      properties:
-        name:
-          description: The user's name
-          type: string
-        companies:
-          description: The companies of the user
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.UserCompany'
-          type: array
-        lastActiveDate:
-          description: The last time the user was active
-          type: string
-        email:
-          description: The user's mail-address
-          type: string
-        id:
-          description: The id of the user
-          type: number
-        roles:
-          description: The user's role
-          items:
-            type: string
-          type: array
       required:
-      - companies
-      - email
-      - id
-      - lastActiveDate
-      - name
-      - roles
-      type: object
-    com.patagona.pricemonitor.share.api.UserCompany:
-      additionalProperties: false
-      description: This case class is used for serializing company-information for
-        the account-endpoints
-      example:
-        name: name
-        id: 0.8008281904610115
-        contracts:
-        - name: name
-          active: true
-          id: 6.027456183070403
-          type: type
-          sid: sid
-        - name: name
-          active: true
-          id: 6.027456183070403
-          type: type
-          sid: sid
-      properties:
-        id:
-          description: The company's id
-          type: number
-        name:
-          description: The company's name
-          type: string
-        contracts:
-          description: The company's contracts
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.UserContract'
-          type: array
-      required:
-      - contracts
-      - id
-      - name
-      type: object
+        - taskType
     com.patagona.pricemonitor.share.api.UserContract:
-      additionalProperties: false
-      description: This case class is used for serializing contract-information for
-        the account-endpoints
-      example:
-        name: name
-        active: true
-        id: 6.027456183070403
-        type: type
-        sid: sid
+      description: This case class is used for serializing contract-information for the account-endpoints
       properties:
         name:
-          description: The contract's name
           type: string
+          description: The contract's name
         id:
-          description: The contract's id
           type: number
+          description: The contract's id
         type:
           type: string
         sid:
-          description: The contract's string-id
           type: string
+          description: The contract's string-id
         active:
-          description: The contract status
           type: boolean
-      required:
-      - active
-      - id
-      - name
-      - sid
-      - type
-      type: object
-    GetOffersApiResponse:
+          description: The contract status
       additionalProperties: false
-      example:
-        data:
-        - offers:
-          - ignored: true
-            gtin: 6
-            productId: productId
-            retrievalDate: 2000-01-23T04:56:07.000+00:00
-            availability: true
-            creationDate: 2000-01-23T04:56:07.000+00:00
-            vendorName: vendorName
-            positionByTotalPrice: 2
-            productName: productName
-            url: url
-            minDeliveryTime: 5
-            vendorDomainId: vendorDomainId
-            deliveryCosts: 0.8008281904610115
-            maxDeliveryTime: 1
-            price: 7.061401241503109
-            domain: domain
-            contractId: contractId
-            attributes:
-            - name: name
-              value: value
-            - name: name
-              value: value
-            currency: currency
-            positionByUnitPrice: 5
-          - ignored: true
-            gtin: 6
-            productId: productId
-            retrievalDate: 2000-01-23T04:56:07.000+00:00
-            availability: true
-            creationDate: 2000-01-23T04:56:07.000+00:00
-            vendorName: vendorName
-            positionByTotalPrice: 2
-            productName: productName
-            url: url
-            minDeliveryTime: 5
-            vendorDomainId: vendorDomainId
-            deliveryCosts: 0.8008281904610115
-            maxDeliveryTime: 1
-            price: 7.061401241503109
-            domain: domain
-            contractId: contractId
-            attributes:
-            - name: name
-              value: value
-            - name: name
-              value: value
-            currency: currency
-            positionByUnitPrice: 5
-          product:
-            customerProductId: customerProductId
-            gtin: 9
-            referencePrice: 4.145608029883936
-            maxPriceBoundary: 3.616076749251911
-            name: name
-            id: id
-            minPriceBoundary: 2.027123023002322
-            tags:
-            - value: value
-              key: key
-            - value: value
-              key: key
-        - offers:
-          - ignored: true
-            gtin: 6
-            productId: productId
-            retrievalDate: 2000-01-23T04:56:07.000+00:00
-            availability: true
-            creationDate: 2000-01-23T04:56:07.000+00:00
-            vendorName: vendorName
-            positionByTotalPrice: 2
-            productName: productName
-            url: url
-            minDeliveryTime: 5
-            vendorDomainId: vendorDomainId
-            deliveryCosts: 0.8008281904610115
-            maxDeliveryTime: 1
-            price: 7.061401241503109
-            domain: domain
-            contractId: contractId
-            attributes:
-            - name: name
-              value: value
-            - name: name
-              value: value
-            currency: currency
-            positionByUnitPrice: 5
-          - ignored: true
-            gtin: 6
-            productId: productId
-            retrievalDate: 2000-01-23T04:56:07.000+00:00
-            availability: true
-            creationDate: 2000-01-23T04:56:07.000+00:00
-            vendorName: vendorName
-            positionByTotalPrice: 2
-            productName: productName
-            url: url
-            minDeliveryTime: 5
-            vendorDomainId: vendorDomainId
-            deliveryCosts: 0.8008281904610115
-            maxDeliveryTime: 1
-            price: 7.061401241503109
-            domain: domain
-            contractId: contractId
-            attributes:
-            - name: name
-              value: value
-            - name: name
-              value: value
-            currency: currency
-            positionByUnitPrice: 5
-          product:
-            customerProductId: customerProductId
-            gtin: 9
-            referencePrice: 4.145608029883936
-            maxPriceBoundary: 3.616076749251911
-            name: name
-            id: id
-            minPriceBoundary: 2.027123023002322
-            tags:
-            - value: value
-              key: key
-            - value: value
-              key: key
+      type: object
+      required:
+        - active
+        - sid
+        - id
+        - name
+        - type
+    com.patagona.pricemonitor.share.api.UserCompany:
+      description: This case class is used for serializing company-information for the account-endpoints
+      properties:
+        id:
+          type: number
+          description: The company's id
+        name:
+          type: string
+          description: The company's name
+        contracts:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.UserContract'
+          description: The company's contracts
+      additionalProperties: false
+      type: object
+      required:
+        - id
+        - name
+        - contracts
+    com.patagona.pricemonitor.share.api.UserInfo:
+      description: This case class is used for serializing user-information for the account-endpoints
+      properties:
+        name:
+          type: string
+          description: The user's name
+        companies:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.UserCompany'
+          description: The companies of the user
+        lastActiveDate:
+          type: string
+          description: The last time the user was active
+        email:
+          type: string
+          description: The user's mail-address
+        id:
+          type: number
+          description: The id of the user
+        roles:
+          type: array
+          items:
+            type: string
+          description: The user's role
+      additionalProperties: false
+      type: object
+      required:
+        - roles
+        - companies
+        - email
+        - id
+        - lastActiveDate
+        - name
+    GetOffersApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
       properties:
         data:
           items:
-            $ref: '#/components/schemas/ProductAndOffers_2'
+            $ref: '#/components/schemas/ProductAndOffers'
           type: array
-      required:
-      - data
-      type: object
-    GetShopsByDomainResponseV3ApiResponse:
+    com.patagona.pricemonitor.share.api.GetShopsByDomainResponseV3:
+      description: Describes a domain and its corresponding shops
+      properties:
+        domain:
+          type: string
+          description: domain name
+        shops:
+          type: array
+          items:
+            type: string
+          uniqueItems: true
+          description: shop names which have offers in the domain for a given time range
       additionalProperties: false
-      example:
-        data:
-        - domain: domain
-          shops:
-          - shops
-          - shops
-        - domain: domain
-          shops:
-          - shops
-          - shops
+      type: object
+      required:
+        - domain
+        - shops
+    GetShopsByDomainResponseV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
       properties:
         data:
           items:
             $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.GetShopsByDomainResponseV3'
           type: array
-      required:
-      - data
-      type: object
     com.patagona.pricemonitor.share.api.QueryOffersOfShopRequestV3:
-      additionalProperties: false
       properties:
         shop:
           type: string
         endDate:
-          format: date-time
           type: string
+          format: date-time
         start:
           type: integer
         limit:
           type: integer
         startDate:
+          type: string
           format: date-time
-          type: string
-      required:
-      - endDate
-      - limit
-      - shop
-      - start
-      - startDate
-      type: object
-    QueryOffersOfShopV3ApiResponse:
       additionalProperties: false
-      example:
-        data:
-        - ignored: true
-          gtin: 2.3021358869347655
-          productId: productId
-          retrievalDate: 2000-01-23T04:56:07.000+00:00
-          availability: true
-          vendorName: vendorName
-          creationDate: 2000-01-23T04:56:07.000+00:00
-          positionByTotalPrice: 0
-          url: url
-          productName: productName
-          minDeliveryTime: 5
-          vendorDomainId: vendorDomainId
-          deliveryCosts: 6.027456183070403
-          maxDeliveryTime: 1
-          price: 5.962133916683182
-          domain: domain
-          attributes:
-          - name: name
-            value: value
-          - name: name
-            value: value
-          currency: currency
-          positionByUnitPrice: 7
-        - ignored: true
-          gtin: 2.3021358869347655
-          productId: productId
-          retrievalDate: 2000-01-23T04:56:07.000+00:00
-          availability: true
-          vendorName: vendorName
-          creationDate: 2000-01-23T04:56:07.000+00:00
-          positionByTotalPrice: 0
-          url: url
-          productName: productName
-          minDeliveryTime: 5
-          vendorDomainId: vendorDomainId
-          deliveryCosts: 6.027456183070403
-          maxDeliveryTime: 1
-          price: 5.962133916683182
-          domain: domain
-          attributes:
-          - name: name
-            value: value
-          - name: name
-            value: value
-          currency: currency
-          positionByUnitPrice: 7
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiOffer'
-          type: array
-      required:
-      - data
       type: object
-    QueryOfferStatisticsV31ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-        - productId: productId
-          offerCount: 0
-          stats:
-            unitPriceStats:
-              min: 6.027456183070403
-              avg: 1.4658129805029452
-              max: 5.962133916683182
-            domainStats:
-            - competitorOfferCount: 5
-              domain: domain
-            - competitorOfferCount: 5
-              domain: domain
-            totalPriceStats:
-              min: 6.027456183070403
-              avg: 1.4658129805029452
-              max: 5.962133916683182
-        - productId: productId
-          offerCount: 0
-          stats:
-            unitPriceStats:
-              min: 6.027456183070403
-              avg: 1.4658129805029452
-              max: 5.962133916683182
-            domainStats:
-            - competitorOfferCount: 5
-              domain: domain
-            - competitorOfferCount: 5
-              domain: domain
-            totalPriceStats:
-              min: 6.027456183070403
-              avg: 1.4658129805029452
-              max: 5.962133916683182
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostOfferStatisticsResponseV31'
-          type: array
       required:
-      - data
-      type: object
-    GetOfferStatisticsV3ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-        - productId: productId
-          statsByDomain:
-          - offerCount: 0
-            domain: domain
-            minPrice: 6.027456183070403
-            averagePrice: 1.4658129805029452
-          - offerCount: 0
-            domain: domain
-            minPrice: 6.027456183070403
-            averagePrice: 1.4658129805029452
-        - productId: productId
-          statsByDomain:
-          - offerCount: 0
-            domain: domain
-            minPrice: 6.027456183070403
-            averagePrice: 1.4658129805029452
-          - offerCount: 0
-            domain: domain
-            minPrice: 6.027456183070403
-            averagePrice: 1.4658129805029452
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.GetOfferStatisticsV3'
-          type: array
-      required:
-      - data
-      type: object
-    PutProductsApiResponse:
-      additionalProperties: false
-      example:
-        data:
-          id: id
-          url: url
-      properties:
-        data:
-          $ref: '#/components/schemas/Task'
-      required:
-      - data
-      type: object
-    QueryOffersApiResponse:
-      additionalProperties: false
-      example:
-        data:
-        - ignored: true
-          gtin: 6
-          productId: productId
-          retrievalDate: 2000-01-23T04:56:07.000+00:00
-          availability: true
-          creationDate: 2000-01-23T04:56:07.000+00:00
-          vendorName: vendorName
-          positionByTotalPrice: 2
-          productName: productName
-          url: url
-          minDeliveryTime: 5
-          vendorDomainId: vendorDomainId
-          deliveryCosts: 0.8008281904610115
-          maxDeliveryTime: 1
-          price: 7.061401241503109
-          domain: domain
-          contractId: contractId
-          attributes:
-          - name: name
-            value: value
-          - name: name
-            value: value
-          currency: currency
-          positionByUnitPrice: 5
-        - ignored: true
-          gtin: 6
-          productId: productId
-          retrievalDate: 2000-01-23T04:56:07.000+00:00
-          availability: true
-          creationDate: 2000-01-23T04:56:07.000+00:00
-          vendorName: vendorName
-          positionByTotalPrice: 2
-          productName: productName
-          url: url
-          minDeliveryTime: 5
-          vendorDomainId: vendorDomainId
-          deliveryCosts: 0.8008281904610115
-          maxDeliveryTime: 1
-          price: 7.061401241503109
-          domain: domain
-          contractId: contractId
-          attributes:
-          - name: name
-            value: value
-          - name: name
-            value: value
-          currency: currency
-          positionByUnitPrice: 5
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/ApiOffer'
-          type: array
-      required:
-      - data
-      type: object
-    com.patagona.pricemonitor.share.api.PriceDumpingStatsRequest:
-      additionalProperties: false
-      description: A request for price dumping statistics for the given shops.
-      properties:
-        startDate:
-          description: Start of the timerange in which we search for price dumping
-            events
-          format: date-time
-          type: string
-        endDate:
-          description: End of the timerange in which we search for price dumping events
-          format: date-time
-          type: string
-        includeDeliveryCosts:
-          description: Indicates if we consider price + delivery cost to detect price
-            changes or only price
-          type: boolean
-        shops:
-          description: Specifies for which shops we detect price dumping events
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ShopV3'
-          type: array
-          uniqueItems: true
-      required:
-      - endDate
-      - includeDeliveryCosts
-      - shops
-      - startDate
-      type: object
-    com.patagona.pricemonitor.share.api.ShopV3:
-      additionalProperties: false
-      description: A shop, in terms of online shop, sells his products on a certain
-        domain.
-      example:
-        domain: domain
-        name: name
-      properties:
-        domain:
-          description: Domain name
-          type: string
-        name:
-          description: Shop name on given domain.
-          type: string
-      required:
-      - domain
-      - name
-      type: object
-    QueryPriceDumpingStatsApiResponse:
-      additionalProperties: false
-      example:
-        data:
-          statsOverAllomains:
-            potentiallyInitiatedPriceDumpings: 5
-            uniqueProductInitiatedPriceDumpings: 6
-            productsAtMinPrice: 0
-            uniqueProductPotentiallyInitiatedPriceDumpings: 1
-            initiatedPriceDumpings: 5
-          statsPerDomain:
-          - domain: domain
-            productPriceDumpingStats:
-              potentiallyInitiatedPriceDumpings: 5
-              uniqueProductInitiatedPriceDumpings: 6
-              productsAtMinPrice: 0
-              uniqueProductPotentiallyInitiatedPriceDumpings: 1
-              initiatedPriceDumpings: 5
-          - domain: domain
-            productPriceDumpingStats:
-              potentiallyInitiatedPriceDumpings: 5
-              uniqueProductInitiatedPriceDumpings: 6
-              productsAtMinPrice: 0
-              uniqueProductPotentiallyInitiatedPriceDumpings: 1
-              initiatedPriceDumpings: 5
-      properties:
-        data:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PriceDumpingStatsResponse'
-      required:
-      - data
-      type: object
-    com.patagona.pricemonitor.share.api.PutCustomerOrdersRequestV3:
-      additionalProperties: false
-      description: Request body containing bulked orders
-      properties:
-        orders:
-          description: List of orders
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CustomerOrderV3'
-          type: array
-        version:
-          description: Version of orders. Currently only "3" is allowed
-          type: string
-      required:
-      - orders
-      - version
-      type: object
-    com.patagona.pricemonitor.share.api.CustomerOrderV3:
-      additionalProperties: false
-      description: An order placed in a shop.
-      properties:
-        shippingCosts:
-          description: Shipping costs of the order
-          type: number
-        orderId:
-          description: Unique id of an order. It must mean unique in the contract,
-            not in the pricemonitor.
-          type: string
-        items:
-          description: List of bought items
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CustomerOrderItemV2'
-          type: array
-        totalPrice:
-          description: Total price of the order
-          type: number
-        origin:
-          description: Origin of an order, e.g. the online shop where the order is
-            placed
-          type: string
-        creationDate:
-          description: Date when the order is created
-          format: date-time
-          type: string
-        currency:
-          description: 'Currency used in the order. ISO 4217 Currency Codes: e.g.
-            EUR'
-          type: string
-        referrer:
-          description: Referrer of an order. Third party (e.g. marketplace) which
-            referred the customer to the online shop
-          type: string
-      required:
-      - creationDate
-      - currency
-      - items
-      - orderId
-      - origin
-      - shippingCosts
-      - totalPrice
-      type: object
-    PutItemsV3ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-          ids:
-          - ids
-          - ids
-      properties:
-        data:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PutItemsResponseV3'
-      required:
-      - data
-      type: object
-    DeletedItemsApiResponse:
-      additionalProperties: false
-      example:
-        data:
-          deleted: 0
-      properties:
-        data:
-          $ref: '#/components/schemas/DeletedItemsResponse'
-      required:
-      - data
-      type: object
-    com.patagona.pricemonitor.share.api.PostOrderStatisticsRequestV3:
-      additionalProperties: false
-      description: 'Represents a paginated query with an optional product filter and
-        a specified time range. <br> If no filter is provided, the response will contain
-        all available data, paginated according to the `pagination` parameter. <br>
-        <br> Notes: <br> - At maximum it''s allowed to query 10,000 records (pagination
-        limit). <br> - The maximum time span between the start and end should not
-        exceed 30 days (timerange limit).'
-      properties:
-        pagination:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Pagination'
-        range:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ZonedTimeRange'
-        filter:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.OneOfProductsQuery'
-      required:
-      - pagination
-      - range
-      type: object
-    com.patagona.pricemonitor.share.api.Pagination:
-      additionalProperties: false
-      description: This model describes a step in a paginated endpoint. It consists
-        of the start index, set to 0 for the first page. The next page starts at (previous
-        start) + limit. Reasonable values for the limit parameter depend on the specific
-        endpoint.
-      properties:
-        start:
-          type: integer
-        limit:
-          type: integer
-      required:
-      - limit
-      - start
-      type: object
-    com.patagona.pricemonitor.share.api.ZonedTimeRange:
-      additionalProperties: false
-      description: Represents a time range. It's required that the end timestamp is
-        after or equals the start timestamp.
-      properties:
-        start:
-          description: The starting point of the time range, represented as a timestamp
-            in ISO 8601 format (e.g., "2023-10-19T13:45:30Z") in UTC.
-          format: date-time
-          type: string
-        end:
-          description: The ending point of the time range, represented as a timestamp
-            in ISO 8601 format (e.g., "2023-10-19T14:45:30Z") in UTC.
-          format: date-time
-          type: string
-      required:
-      - end
-      - start
-      type: object
-    com.patagona.pricemonitor.share.api.OneOfProductsQuery:
-      additionalProperties: false
-      description: An optional parameter to further filter the data based on product
-        criteria.
-      properties:
-        oneOf:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ProductIdQuery'
-      required:
-      - oneOf
-      type: object
-    com.patagona.pricemonitor.share.api.ProductIdQuery:
-      additionalProperties: false
-      description: This product query evaluates to 'true' if the value of the 'field'
-        is one on the specified 'values'.
-      properties:
-        field:
-          description: 'Specifies the attribute to filter by. It accepts two values:
-            <br> - "customerProductId": Your unique identifier for the product. <br>
-            - "productId": Patagona''s internal product id (must be a numerical integer).'
-          type: string
-        values:
-          description: An array of strings containing the ids of the products to be
-            queried.
-          items:
-            type: string
-          type: array
-      required:
-      - field
-      - values
-      type: object
-    QueryOrderStatisticsV3ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-        - itemId: itemId
-          productId: productId
-          numberOfSoldItems: 0
-        - itemId: itemId
-          productId: productId
-          numberOfSoldItems: 0
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostOrderStatisticsResponseV3'
-          type: array
-      required:
-      - data
-      type: object
-    com.patagona.pricemonitor.share.api.DeleteOrdersByQueryRequestV3:
-      additionalProperties: false
-      description: 'Request to delete a list of customer orders by providing an order
-        query Notes: <br> - At maximum it''s allowed to provide 10,000 order queries
-        per request. <br>'
-      properties:
-        orders:
-          description: List of order queries, each query should include an order id
-            and its corresponding creation date
-          items:
-            $ref: '#/components/schemas/com_patagona_pricemonitor_share_api_DeleteOrdersByQueryRequestV3_orders'
-          type: array
-      required:
-      - orders
-      type: object
-    GetExtendedTagsApiResponse:
-      additionalProperties: false
-      example:
-        data:
-        - stringValue: stringValue
-          booleanValue: true
-          integerValue: 6
-          doubleValue: 0.8008281904610115
-          label: label
-        - stringValue: stringValue
-          booleanValue: true
-          integerValue: 6
-          doubleValue: 0.8008281904610115
-          label: label
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/ExtendedTag'
-          type: array
-      required:
-      - data
-      type: object
-    com.patagona.pricemonitor.share.api.AdminCompanyV2:
-      additionalProperties: false
-      description: A company with its contracts used for data representation in the
-        admin-endpoint
-      example:
-        name: name
-        id: 0.8008281904610115
-        contracts:
-        - description: description
-          active: true
-          id: id
-          creationDate: 2000-01-23T04:56:07.000+00:00
-          expirationDate: 2000-01-23T04:56:07.000+00:00
-        - description: description
-          active: true
-          id: id
-          creationDate: 2000-01-23T04:56:07.000+00:00
-          expirationDate: 2000-01-23T04:56:07.000+00:00
-      properties:
-        id:
-          description: The id of the company
-          type: number
-        name:
-          description: The company's name
-          type: string
-        contracts:
-          description: A list of the comapny's contracts
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.AdminContractV2'
-          type: array
-      required:
-      - contracts
-      - id
-      - name
-      type: object
-    com.patagona.pricemonitor.share.api.AdminContractV2:
-      additionalProperties: false
-      description: A contract used for data representation in the admin-endpoint
-      example:
-        description: description
-        active: true
-        id: id
-        creationDate: 2000-01-23T04:56:07.000+00:00
-        expirationDate: 2000-01-23T04:56:07.000+00:00
-      properties:
-        expirationDate:
-          description: The date and time the contract expires
-          format: date-time
-          type: string
-        description:
-          description: The contract's description
-          type: string
-        id:
-          description: The id of the contract
-          type: string
-        creationDate:
-          description: The date and time the contract was created
-          format: date-time
-          type: string
-        type:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ContractType'
-        active:
-          description: The contract-status
-          type: boolean
-      required:
-      - active
-      - creationDate
-      - description
-      - id
-      - type
-      type: object
-    com.patagona.pricemonitor.share.api.ContractType:
-      enum:
-      - Pricemonitor for manufacturers
-      - Pricemonitor for resellers
-      type: string
-    com.patagona.pricemonitor.share.api.GetContractSettingsResponseV1:
-      additionalProperties: false
-      example:
-        portals:
-        - portals
-        - portals
-        msrpTag: msrpTag
-        active: true
-        type: type
-        monitoringPriority: 6
-        sid: sid
-        features:
-          disabled:
-          - disabled
-          - disabled
-          enabled:
-          - enabled
-          - enabled
-        mapTag: mapTag
-        name: name
-        company: company
-        currency: currency
-        includeDeliveryCosts: true
-        id: 0.8008281904610115
-        imageTag: imageTag
-        expirationDate: 2000-01-23T04:56:07.000+00:00
+        - start
+        - shop
+        - endDate
+        - limit
+        - startDate
+    com.patagona.pricemonitor.share.api.OfferAttribute:
+      description: Created by Andreas Frankenberger on 28.01.16.
       properties:
         name:
           type: string
-        expirationDate:
-          format: date-time
+        value:
           type: string
-        portals:
-          items:
-            type: string
-          type: array
-        includeDeliveryCosts:
-          type: boolean
-        features:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ContractFeatures'
-        imageTag:
-          description: The name of the tag that contains the product image url
-          type: string
-        company:
-          type: string
-        id:
-          type: number
-        monitoringPriority:
-          description: Priority of the contract in the monitoring queue
-          type: integer
-        currency:
-          description: The contract's currency as three letter code
-          type: string
-        type:
-          type: string
-        sid:
-          type: string
-        msrpTag:
-          description: The name of the tag that contains the manufacturers suggested
-            retail price
-          type: string
-        mapTag:
-          description: The name of the tag that contains the minimum advertised price
-          type: string
-        active:
-          type: boolean
+      additionalProperties: false
+      type: object
       required:
-      - active
-      - company
-      - currency
-      - features
-      - id
-      - includeDeliveryCosts
-      - monitoringPriority
-      - name
-      - portals
-      - sid
-      - type
-      type: object
-    com.patagona.pricemonitor.share.api.ContractFeatures:
-      additionalProperties: false
-      example:
-        disabled:
-        - disabled
-        - disabled
-        enabled:
-        - enabled
-        - enabled
-      properties:
-        disabled:
-          items:
-            type: string
-          type: array
-        enabled:
-          items:
-            type: string
-          type: array
-      required:
-      - disabled
-      - enabled
-      type: object
-    com.patagona.pricemonitor.share.api.PutAdminContractSettingsBody:
-      additionalProperties: false
-      example:
-        features:
-          disabled:
-          - disabled
-          - disabled
-          enabled:
-          - enabled
-          - enabled
-        portals:
-        - portals
-        - portals
-        name: name
-        active: true
-        id: 0.8008281904610115
-        type: type
-        monitoringPriority: 6
-        expirationDate: 2000-01-23T04:56:07.000+00:00
-        sid: sid
-      properties:
-        name:
-          type: string
-        expirationDate:
-          format: date-time
-          type: string
-        portals:
-          items:
-            type: string
-          type: array
-        features:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ContractFeatures'
-        id:
-          type: number
-        monitoringPriority:
-          type: integer
-        type:
-          type: string
-        sid:
-          type: string
-        active:
-          type: boolean
-      required:
-      - active
-      - features
-      - id
-      - name
-      - portals
-      - sid
-      - type
-      type: object
-    com.patagona.pricemonitor.share.api.ContractStats:
-      additionalProperties: false
-      description: Contract statistics
-      example:
-        offerCount: 5.962133916683182
-        vendorCount: 5.637376656633329
-        portalCount: 6
-        productCount: 0
-        allOfferCount: 1.4658129805029452
-      properties:
-        productCount:
-          description: The count of currently monitored products
-          type: integer
-        portalCount:
-          description: The number of actively monitored domains
-          type: integer
-        allOfferCount:
-          description: The number of offers found for the monitored products without
-            any filters applied
-          type: number
-        offerCount:
-          description: The number of offers found for the monitored products after
-            filtering
-          type: number
-        vendorCount:
-          description: The count of vendors found for the monitored products
-          type: number
-      required:
-      - allOfferCount
-      - offerCount
-      - portalCount
-      - productCount
-      - vendorCount
-      type: object
-    com.patagona.pricemonitor.share.api.PricesByDayByProductIdRequestV2:
-      additionalProperties: false
-      description: A request for all known prices for a given day & product ID. Provides
-        the option to filter the results using the `offerSelectors`.
-      properties:
-        day:
-          description: The day for which to return the prices in ISO 8601
-          format: date-time
-          type: string
-        offers:
-          description: A list of `OfferSelector`s that allows filtering down the results.
-            The selectors are combined using an OR operation. The list must contain
-            at least one element.
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.OfferSelector'
-          type: array
-      required:
-      - day
-      - offers
-      type: object
-    com.patagona.pricemonitor.share.api.OfferSelector:
-      additionalProperties: false
-      description: Whitelist entry for offers based on different attributes.
-      properties:
-        domain:
-          description: The domain
-          type: string
-        vendorName:
-          description: The vendor name
-          type: string
-        productName:
-          description: The product name
-          type: string
-      required:
-      - domain
-      - productName
-      - vendorName
-      type: object
-    com.patagona.pricemonitor.share.api.PricesByDayByProductIdResponseV2:
-      additionalProperties: false
-      description: Contains all known prices for a given day & product ID for one
-        domain & vendor combination.
-      example:
-        domain: domain
-        vendorName: vendorName
-        prices:
-        - deliveryCosts: 6.027456183070403
-          price: 0.8008281904610115
-          timestamp: 2000-01-23T04:56:07.000+00:00
-        - deliveryCosts: 6.027456183070403
-          price: 0.8008281904610115
-          timestamp: 2000-01-23T04:56:07.000+00:00
-        productName: productName
-      properties:
-        domain:
-          description: The domain these prices were found on
-          type: string
-        vendorName:
-          description: The name of the vendor these prices were found for
-          type: string
-        productName:
-          description: The name of the product the vendor is using
-          type: string
-        prices:
-          description: A list of `PricesByDayByProductIdResponsePricePointV2` elements
-            containing the prices
-          items:
-            $ref: '#/components/schemas/com_patagona_pricemonitor_share_api_PricesByDayByProductIdResponseV2_prices'
-          type: array
-      required:
-      - domain
-      - prices
-      - productName
-      - vendorName
-      type: object
-    com.patagona.pricemonitor.share.api.TagFilteredVendorsRequest:
-      additionalProperties: false
-      properties:
-        tags:
-          additionalProperties:
-            type: string
-          description: A list of key value pairs of product tags
-          type: object
-      type: object
-    com.patagona.pricemonitor.share.api.PostVendorsByDomainResponse:
-      additionalProperties: false
-      example:
-        data:
-        - minPriceCount: 5.637376656633329
-          productsUnderReferencePrice: 1.4658129805029452
-          portalName: portalName
-          resellerName: resellerName
-          averagePosition: 6.027456183070403
-          averageDiscount: 0.8008281904610115
-          productsCount: 5.962133916683182
-        - minPriceCount: 5.637376656633329
-          productsUnderReferencePrice: 1.4658129805029452
-          portalName: portalName
-          resellerName: resellerName
-          averagePosition: 6.027456183070403
-          averageDiscount: 0.8008281904610115
-          productsCount: 5.962133916683182
-        totalCount: 2
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ResellerSummaryByDomain'
-          type: array
-        totalCount:
-          type: integer
-      required:
-      - data
-      - totalCount
-      type: object
-    com.patagona.pricemonitor.share.api.ResellerSummaryByDomain:
-      additionalProperties: false
-      example:
-        minPriceCount: 5.637376656633329
-        productsUnderReferencePrice: 1.4658129805029452
-        portalName: portalName
-        resellerName: resellerName
-        averagePosition: 6.027456183070403
-        averageDiscount: 0.8008281904610115
-        productsCount: 5.962133916683182
-      properties:
-        averageDiscount:
-          type: number
-        averagePosition:
-          type: number
-        productsUnderReferencePrice:
-          type: number
-        portalName:
-          type: string
-        productsCount:
-          type: number
-        resellerName:
-          type: string
-        minPriceCount:
-          type: number
-      required:
-      - averageDiscount
-      - averagePosition
-      - minPriceCount
-      - portalName
-      - productsCount
-      - productsUnderReferencePrice
-      - resellerName
-      type: object
-    com.patagona.pricemonitor.share.api.PostProductOfferRequest:
-      additionalProperties: false
-      description: Represents a single request to post offers for a snapshot. A snapshot
-        is a unique combination of productId, creationDate, and domain.
-      example:
-        offers:
-        - retrievalDate: 2000-01-23T04:56:07.000+00:00
-          availability: true
-          vendorName: vendorName
-          url: url
-          productName: productName
-          vendorDomainId: vendorDomainId
-          deliveryCosts: 0.8008281904610115
-          price: 6.027456183070403
-          maxDeliveryHours: 5
-          attributes:
-          - value: value
-            key: key
-          - value: value
-            key: key
-          currency: currency
-          id: id
-          minDeliveryHours: 1
-        - retrievalDate: 2000-01-23T04:56:07.000+00:00
-          availability: true
-          vendorName: vendorName
-          url: url
-          productName: productName
-          vendorDomainId: vendorDomainId
-          deliveryCosts: 0.8008281904610115
-          price: 6.027456183070403
-          maxDeliveryHours: 5
-          attributes:
-          - value: value
-            key: key
-          - value: value
-            key: key
-          currency: currency
-          id: id
-          minDeliveryHours: 1
-        productId: productId
-        domain: domain
-        creationDate: 2000-01-23T04:56:07.000+00:00
-      properties:
-        productId:
-          description: Patagona's internal product id.
-          type: string
-        creationDate:
-          description: ISO 8601 timestamp when the offers have been gathered. This
-            timestamp needs to be more recent compared to already existing offers.
-            Otherwise, the offers will be rejected.
-          format: date-time
-          type: string
-        domain:
-          description: Origin of the offers.
-          type: string
-        offers:
-          description: Non-empty list of offers.
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiOfferV2'
-          type: array
-      required:
-      - creationDate
-      - domain
-      - offers
-      - productId
-      type: object
-    com.patagona.pricemonitor.share.api.ApiOfferV2:
-      additionalProperties: false
-      description: Represents an offer for a product on a certain domain.
-      example:
-        retrievalDate: 2000-01-23T04:56:07.000+00:00
-        availability: true
-        vendorName: vendorName
-        url: url
-        productName: productName
-        vendorDomainId: vendorDomainId
-        deliveryCosts: 0.8008281904610115
-        price: 6.027456183070403
-        maxDeliveryHours: 5
-        attributes:
-        - value: value
-          key: key
-        - value: value
-          key: key
-        currency: currency
-        id: id
-        minDeliveryHours: 1
-      properties:
-        deliveryCosts:
-          description: The additional charges for delivering the product to the customer's
-            location.
-          type: number
-        url:
-          description: The direct link to the product page on the domain where this
-            offer can be found.
-          type: string
-        vendorDomainId:
-          description: Optional identifier representing the vendor on a certain domain.
-          type: string
-        price:
-          description: The current listed unit price of the product.
-          type: number
-        availability:
-          description: An optional flag indicating whether the product is currently
-            in stock and available for purchase.
-          type: boolean
-        attributes:
-          description: A list of additional offer details.
-          items:
-            $ref: '#/components/schemas/com_patagona_pricemonitor_share_api_ApiOfferV2_attributes'
-          type: array
-        vendorName:
-          description: The display name of the shop which sells the product.
-          type: string
-        retrievalDate:
-          description: Optional timestamp based on ISO 8601 when this offer information
-            was last fetched from the domain.
-          format: date-time
-          type: string
-        id:
-          description: A unique identifier for the offer. It's crucial that it's unique
-            across all offers independent of the timestamp. If you don't have a unique
-            identifier then please use a UUID.
-          type: string
-        productName:
-          description: The name of the product as listed on the domain.
-          type: string
-        currency:
-          description: The currency in which the price and delivery costs are expressed.
-            Allowed values are ISO 4217 currency codes like "EUR".
-          type: string
-        minDeliveryHours:
-          description: Optional minimum time, in hours, it takes for the product to
-            be delivered to the customer.
-          type: integer
-        maxDeliveryHours:
-          description: Optional maximum time, in hours, it takes for the product to
-            be delivered to the customer.
-          type: integer
-      required:
-      - attributes
-      - currency
-      - deliveryCosts
-      - id
-      - price
-      - productName
-      - url
-      - vendorName
-      type: object
-    QueryPriceRecommendationsV2ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-        - relativePriceChangePercentage: 3.616076749251911
-          customerProductId: customerProductId
-          gtin: 9.301444243932576
-          productId: productId
-          originalTags:
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          oldPrice: 0.8008281904610115
-          tags:
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          originalMaxPriceBoundary: 4.145608029883936
-          newPosition: 2
-          originalMinPriceBoundary: 7.386281948385884
-          oldDeliveryCosts: 1.4658129805029452
-          deliveryCosts: 6.027456183070403
-          price: 2.3021358869347655
-          relevantDomain: relevantDomain
-          currency: currency
-          oldPosition: 7
-          timestamp: 2000-01-23T04:56:07.000+00:00
-        - relativePriceChangePercentage: 3.616076749251911
-          customerProductId: customerProductId
-          gtin: 9.301444243932576
-          productId: productId
-          originalTags:
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          oldPrice: 0.8008281904610115
-          tags:
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          originalMaxPriceBoundary: 4.145608029883936
-          newPosition: 2
-          originalMinPriceBoundary: 7.386281948385884
-          oldDeliveryCosts: 1.4658129805029452
-          deliveryCosts: 6.027456183070403
-          price: 2.3021358869347655
-          relevantDomain: relevantDomain
-          currency: currency
-          oldPosition: 7
-          timestamp: 2000-01-23T04:56:07.000+00:00
-        meta:
-          totalSize: 1
-          start: 1
-          limit: 1
-          nextUrl: nextUrl
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiPriceRecommendation'
-          type: array
-        meta:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PaginationResponse'
-      required:
-      - data
-      type: object
-    com.patagona.pricemonitor.share.api.PutResetPasswordRequest:
-      additionalProperties: false
-      description: Request body for resetting the password
-      properties:
-        token:
-          description: Received via email after requesting a new password.
-          type: string
-        password:
-          description: Password entered by the user.
-          type: string
-      required:
-      - password
-      - token
-      type: object
-    com.patagona.pricemonitor.share.api.PostNewPasswordRequest:
-      additionalProperties: false
-      description: Request body for requesting a new password
-      properties:
-        email:
-          description: Valid email address of an existing pricemonitor account.
-          type: string
-      required:
-      - email
-      type: object
-    GetManufacturerV3ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-          companyId: 0.8008281904610115
-          description: description
-          active: true
-          creationDate: 2000-01-23T04:56:07.000+00:00
-          expirationDate: 2000-01-23T04:56:07.000+00:00
-          sid: sid
-      properties:
-        data:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.GetContractResponseV3'
-      required:
-      - data
-      type: object
-    QueryProductsByFilterManufacturerV3ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-        - customerProductId: customerProductId
-          gtin: 6.027456183070403
-          referencePrice: 5.962133916683182
-          maxPriceBoundary: 1.4658129805029452
-          name: name
-          id: id
-          minPriceBoundary: 0.8008281904610115
-          tags:
-          - value: value
-            key: key
-          - value: value
-            key: key
-        - customerProductId: customerProductId
-          gtin: 6.027456183070403
-          referencePrice: 5.962133916683182
-          maxPriceBoundary: 1.4658129805029452
-          name: name
-          id: id
-          minPriceBoundary: 0.8008281904610115
-          tags:
-          - value: value
-            key: key
-          - value: value
-            key: key
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiProduct'
-          type: array
-      required:
-      - data
-      type: object
-    com.patagona.pricemonitor.share.api.ApiQuery:
-      additionalProperties: false
-      description: This model represents a paginated query. The filter parameter is
-        optional, if it is not set, all values will be returned, paginated by the
-        pagination parameter.
-      properties:
-        pagination:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Pagination'
-        filter:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Query'
-      required:
-      - pagination
-      type: object
-    com.patagona.pricemonitor.share.api.Query:
-      additionalProperties: false
-      description: |-
-        This class specifies a general query language, even though all fields are marked as optional, exactly one has
-        to be specified.
-        Please note that depending on the endpoint only a subset of the query language might be supported.
-        Refer to the endpoint specific documentation to view the restrictions.
-      example:
-        regex:
-          field: field
-          pattern: pattern
-        oneOf:
-          field: field
-          values:
-          - values
-          - values
-        or:
-        - null
-        - null
-        const: true
-        in:
-          field: field
-        and:
-        - null
-        - null
-        lt:
-          field: field
-          value: value
-        eq:
-          field: field
-          value: value
-        gt:
-          field: field
-          value: value
-      properties:
-        regex:
-          $ref: '#/components/schemas/com_patagona_pricemonitor_share_api_Query_regex'
-        in:
-          $ref: '#/components/schemas/com_patagona_pricemonitor_share_api_Query_in'
-        or:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Query'
-          type: array
-        const:
-          type: boolean
-        not:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Query'
-        oneOf:
-          $ref: '#/components/schemas/com_patagona_pricemonitor_share_api_Query_oneOf'
-        lt:
-          $ref: '#/components/schemas/com_patagona_pricemonitor_share_api_Query_lt'
-        gt:
-          $ref: '#/components/schemas/com_patagona_pricemonitor_share_api_Query_lt'
-        eq:
-          $ref: '#/components/schemas/com_patagona_pricemonitor_share_api_Query_lt'
-        and:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Query'
-          type: array
-      type: object
-    QueryProductsManufacturerV3ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-        - customerProductId: customerProductId
-          gtin: 6.027456183070403
-          referencePrice: 5.962133916683182
-          maxPriceBoundary: 1.4658129805029452
-          name: name
-          id: id
-          minPriceBoundary: 0.8008281904610115
-          tags:
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-        - customerProductId: customerProductId
-          gtin: 6.027456183070403
-          referencePrice: 5.962133916683182
-          maxPriceBoundary: 1.4658129805029452
-          name: name
-          id: id
-          minPriceBoundary: 0.8008281904610115
-          tags:
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiProductV3'
-          type: array
-      required:
-      - data
-      type: object
-    GetCustomerContractSettingsApiResponse:
-      additionalProperties: false
-      example:
-        data:
-          imageUrlTag: imageUrlTag
-          mapTag: mapTag
-          domains:
-          - domains
-          - domains
-          callbacks:
-            pricemonitorCompleted:
-            - headers:
-                key: headers
-              method: method
-              bodyTemplate: bodyTemplate
-              name: name
-              url: url
-            - headers:
-                key: headers
-              method: method
-              bodyTemplate: bodyTemplate
-              name: name
-              url: url
-          msrpTag: msrpTag
-          currency: EUR
-          includeDeliveryCosts: true
-          dynamicMonitoring:
-            threshold: 6.027456183070403
-            analysisRange: 0
-            adjustedInterval: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CustomerContractSettings'
-      required:
-      - data
-      type: object
-    com.patagona.pricemonitor.share.api.CustomerContractSettings:
-      additionalProperties: false
-      description: CustomerContractSettings contains all settings adjustable by the
-        pricemonitor customers.
-      example:
-        imageUrlTag: imageUrlTag
-        mapTag: mapTag
-        domains:
-        - domains
-        - domains
-        callbacks:
-          pricemonitorCompleted:
-          - headers:
-              key: headers
-            method: method
-            bodyTemplate: bodyTemplate
-            name: name
-            url: url
-          - headers:
-              key: headers
-            method: method
-            bodyTemplate: bodyTemplate
-            name: name
-            url: url
-        msrpTag: msrpTag
-        currency: EUR
-        includeDeliveryCosts: true
-        dynamicMonitoring:
-          threshold: 6.027456183070403
-          analysisRange: 0
-          adjustedInterval: 1
-      properties:
-        includeDeliveryCosts:
-          type: boolean
-        domains:
-          items:
-            type: string
-          type: array
-        dynamicMonitoring:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.DynamicMonitoringSettings'
-        currency:
-          default: EUR
-          description: The contract's currency as three letter code
-          type: string
-        imageUrlTag:
-          description: The name of the tag that contains the product image url
-          type: string
-        callbacks:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Callbacks'
-        msrpTag:
-          description: The name of the tag that contains the manufacturers suggested
-            retail price
-          type: string
-        mapTag:
-          description: The name of the tag that contains the minimum advertised price
-          type: string
-      required:
-      - domains
-      - includeDeliveryCosts
-      type: object
-    com.patagona.pricemonitor.share.api.DynamicMonitoringSettings:
-      additionalProperties: false
-      example:
-        threshold: 6.027456183070403
-        analysisRange: 0
-        adjustedInterval: 1
-      properties:
-        analysisRange:
-          type: integer
-        threshold:
-          type: number
-        adjustedInterval:
-          type: integer
-      required:
-      - adjustedInterval
-      - analysisRange
-      - threshold
-      type: object
-    com.patagona.pricemonitor.share.api.Callbacks:
-      additionalProperties: false
-      example:
-        pricemonitorCompleted:
-        - headers:
-            key: headers
-          method: method
-          bodyTemplate: bodyTemplate
-          name: name
-          url: url
-        - headers:
-            key: headers
-          method: method
-          bodyTemplate: bodyTemplate
-          name: name
-          url: url
-      properties:
-        pricemonitorCompleted:
-          items:
-            $ref: '#/components/schemas/com_patagona_pricemonitor_share_api_Callbacks_pricemonitorCompleted'
-          type: array
-      required:
-      - pricemonitorCompleted
-      type: object
-    PutCustomerContractSettingsApiResponse:
-      additionalProperties: false
-      example:
-        data:
-          imageUrlTag: imageUrlTag
-          mapTag: mapTag
-          domains:
-          - domains
-          - domains
-          callbacks:
-            pricemonitorCompleted:
-            - headers:
-                key: headers
-              method: method
-              bodyTemplate: bodyTemplate
-              name: name
-              url: url
-            - headers:
-                key: headers
-              method: method
-              bodyTemplate: bodyTemplate
-              name: name
-              url: url
-          msrpTag: msrpTag
-          currency: EUR
-          includeDeliveryCosts: true
-          dynamicMonitoring:
-            threshold: 6.027456183070403
-            analysisRange: 0
-            adjustedInterval: 1
-      properties:
-        data:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CustomerContractSettings'
-      required:
-      - data
-      type: object
-    GetProductMonitoringStatusVendorV3ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-        - productId: 0.8008281904610115
-          statusOnDomain:
-          - completedAt: 2000-01-23T04:56:07.000+00:00
-            domain: domain
-            startedAt: 2000-01-23T04:56:07.000+00:00
-            outcome:
-              outcome: outcome
-              successful: true
-          - completedAt: 2000-01-23T04:56:07.000+00:00
-            domain: domain
-            startedAt: 2000-01-23T04:56:07.000+00:00
-            outcome:
-              outcome: outcome
-              successful: true
-        - productId: 0.8008281904610115
-          statusOnDomain:
-          - completedAt: 2000-01-23T04:56:07.000+00:00
-            domain: domain
-            startedAt: 2000-01-23T04:56:07.000+00:00
-            outcome:
-              outcome: outcome
-              successful: true
-          - completedAt: 2000-01-23T04:56:07.000+00:00
-            domain: domain
-            startedAt: 2000-01-23T04:56:07.000+00:00
-            outcome:
-              outcome: outcome
-              successful: true
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ProductMonitoringStatus'
-          type: array
-      required:
-      - data
-      type: object
-    GetProductMonitoringStatusStatsVendorV3ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-        - outcomes:
-          - count: 1
-            outcome: outcome
-          - count: 1
-            outcome: outcome
-          domain: domain
-          started: 0
-          completed: 6
-        - outcomes:
-          - count: 1
-            outcome: outcome
-          - count: 1
-            outcome: outcome
-          domain: domain
-          started: 0
-          completed: 6
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ProductMonitoringStatusStats'
-          type: array
-      required:
-      - data
-      type: object
-    QueryProductsByFilterVendorV3ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-        - customerProductId: customerProductId
-          gtin: 6.027456183070403
-          referencePrice: 5.962133916683182
-          maxPriceBoundary: 1.4658129805029452
-          name: name
-          id: id
-          minPriceBoundary: 0.8008281904610115
-          tags:
-          - value: value
-            key: key
-          - value: value
-            key: key
-        - customerProductId: customerProductId
-          gtin: 6.027456183070403
-          referencePrice: 5.962133916683182
-          maxPriceBoundary: 1.4658129805029452
-          name: name
-          id: id
-          minPriceBoundary: 0.8008281904610115
-          tags:
-          - value: value
-            key: key
-          - value: value
-            key: key
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiProduct'
-          type: array
-      required:
-      - data
-      type: object
-    GetPriceRecommendationHistoryApiResponse:
-      additionalProperties: false
-      example:
-        data:
-        - relativePriceChangePercentage: 3.616076749251911
-          customerProductId: customerProductId
-          gtin: 9.301444243932576
-          productId: productId
-          originalTags:
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          oldPrice: 0.8008281904610115
-          tags:
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          originalMaxPriceBoundary: 4.145608029883936
-          newPosition: 2
-          originalMinPriceBoundary: 7.386281948385884
-          oldDeliveryCosts: 1.4658129805029452
-          deliveryCosts: 6.027456183070403
-          price: 2.3021358869347655
-          relevantDomain: relevantDomain
-          currency: currency
-          oldPosition: 7
-          timestamp: 2000-01-23T04:56:07.000+00:00
-        - relativePriceChangePercentage: 3.616076749251911
-          customerProductId: customerProductId
-          gtin: 9.301444243932576
-          productId: productId
-          originalTags:
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          oldPrice: 0.8008281904610115
-          tags:
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          originalMaxPriceBoundary: 4.145608029883936
-          newPosition: 2
-          originalMinPriceBoundary: 7.386281948385884
-          oldDeliveryCosts: 1.4658129805029452
-          deliveryCosts: 6.027456183070403
-          price: 2.3021358869347655
-          relevantDomain: relevantDomain
-          currency: currency
-          oldPosition: 7
-          timestamp: 2000-01-23T04:56:07.000+00:00
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiPriceRecommendation'
-          type: array
-      required:
-      - data
-      type: object
-    QueryProductsVendorV3ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-        - customerProductId: customerProductId
-          gtin: 6.027456183070403
-          referencePrice: 5.962133916683182
-          maxPriceBoundary: 1.4658129805029452
-          name: name
-          id: id
-          minPriceBoundary: 0.8008281904610115
-          tags:
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-        - customerProductId: customerProductId
-          gtin: 6.027456183070403
-          referencePrice: 5.962133916683182
-          maxPriceBoundary: 1.4658129805029452
-          name: name
-          id: id
-          minPriceBoundary: 0.8008281904610115
-          tags:
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-          - stringValue: stringValue
-            integerValue: 5
-            booleanValue: true
-            doubleValue: 5.962133916683182
-            label: label
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiProductV3'
-          type: array
-      required:
-      - data
-      type: object
-    com.patagona.pricemonitor.share.api.PostEmbedSSOUrlRequestV3:
-      additionalProperties: false
-      description: Request body to retrieve signed embed sso url using looker api.
-      properties:
-        url:
-          description: The complete URL of the Looker UI page to display in the embed
-            context.
-          type: string
-      required:
-      - url
-      type: object
-    EmbedSSOUrlResponseV3ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-          url: url
-      properties:
-        data:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.EmbedSSOUrlResponseV3'
-      required:
-      - data
-      type: object
-    com.patagona.pricemonitor.share.api.PostActivateMarketplaceRequestV3:
-      additionalProperties: false
-      description: Payload for activating marketplace of a seller in our system.
-      properties:
-        marketplaceCountryCode:
-          description: Marketplace country code. You can view complete list here.
-            https://developer-docs.amazon.com/sp-api/docs/marketplace-ids. Currently,
-            only Europe as a region is supported.
-          type: string
-        contractId:
-          description: Pricemonitor contract id
-          type: string
-      required:
-      - contractId
-      - marketplaceCountryCode
-      type: object
-    ActivateMarketplaceResponseV3ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-          activated: true
-      properties:
-        data:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ActivateMarketplaceResponseV3'
-      required:
-      - data
-      type: object
-    GetAuthorizationStatusResponseV3ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-          authorized: true
-      properties:
-        data:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.GetAuthorizationStatusResponseV3'
-      required:
-      - data
-      type: object
-    com.patagona.pricemonitor.share.api.PostAuthorizeSellerRequestV3:
-      additionalProperties: false
-      description: Seller to be authorized.
-      properties:
-        sellingPartnerId:
-          description: The identifier for the selling partner seller on Amazon.
-          type: string
-        spapiOauthCode:
-          description: The Login with Amazon (LWA) authorization code that you exchange
-            for an LWA refresh token.
-          type: string
-      required:
-      - sellingPartnerId
-      - spapiOauthCode
-      type: object
-    PostAuthorizeSellerResponseV3ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-          sellerId: 0
-      properties:
-        data:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostAuthorizeSellerResponseV3'
-      required:
-      - data
-      type: object
-    GetMonitoringSchedulesApiResponse:
-      additionalProperties: false
-      example:
-        data:
-        - schedulerJobId: schedulerJobId
-          schedule: schedule
-          domainQuery:
-            regex:
-              field: field
-              pattern: pattern
-            oneOf:
-              field: field
-              values:
-              - values
-              - values
-            or:
-            - null
-            - null
-            const: true
-            in:
-              field: field
-            and:
-            - null
-            - null
-            lt:
-              field: field
-              value: value
-            eq:
-              field: field
-              value: value
-            gt:
-              field: field
-              value: value
-          quota: 0.8008281904610115
-          unfulfilledOnly: true
-          id: 6.027456183070403
-          productQuery:
-            regex:
-              field: field
-              pattern: pattern
-            oneOf:
-              field: field
-              values:
-              - values
-              - values
-            or:
-            - null
-            - null
-            const: true
-            in:
-              field: field
-            and:
-            - null
-            - null
-            lt:
-              field: field
-              value: value
-            eq:
-              field: field
-              value: value
-            gt:
-              field: field
-              value: value
-        - schedulerJobId: schedulerJobId
-          schedule: schedule
-          domainQuery:
-            regex:
-              field: field
-              pattern: pattern
-            oneOf:
-              field: field
-              values:
-              - values
-              - values
-            or:
-            - null
-            - null
-            const: true
-            in:
-              field: field
-            and:
-            - null
-            - null
-            lt:
-              field: field
-              value: value
-            eq:
-              field: field
-              value: value
-            gt:
-              field: field
-              value: value
-          quota: 0.8008281904610115
-          unfulfilledOnly: true
-          id: 6.027456183070403
-          productQuery:
-            regex:
-              field: field
-              pattern: pattern
-            oneOf:
-              field: field
-              values:
-              - values
-              - values
-            or:
-            - null
-            - null
-            const: true
-            in:
-              field: field
-            and:
-            - null
-            - null
-            lt:
-              field: field
-              value: value
-            eq:
-              field: field
-              value: value
-            gt:
-              field: field
-              value: value
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.MonitoringScheduleV3'
-          type: array
-      required:
-      - data
-      type: object
-    com.patagona.pricemonitor.share.api.PostMonitoringScheduleRequestV3:
-      additionalProperties: false
-      description: A request body containing monitoring schedule.
-      properties:
-        productQuery:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Query'
-        quota:
-          description: 'Defines how many products should get monitored. Default to
-            1.0 which means that all products are monitored. Allowed values: 0.0 <
-            quota <= 1.0'
-          type: number
-        domainQuery:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Query'
-        unfulfilledOnly:
-          description: When it's set to true, then the monitoring considers only products
-            on domains where no offers are found within 24h. Default false.
-          type: boolean
-        schedule:
-          description: Only valid CRON expressions are allowed. See Cron spec [[https://www.alonsodomin.me/cron4s/userguide/index.html]]
-          type: string
-      required:
-      - quota
-      - schedule
-      - unfulfilledOnly
-      type: object
-    PutMonitoringSchedulesApiResponse:
-      additionalProperties: false
-      example:
-        data:
-          schedulerJobId: schedulerJobId
-          schedule: schedule
-          domainQuery:
-            regex:
-              field: field
-              pattern: pattern
-            oneOf:
-              field: field
-              values:
-              - values
-              - values
-            or:
-            - null
-            - null
-            const: true
-            in:
-              field: field
-            and:
-            - null
-            - null
-            lt:
-              field: field
-              value: value
-            eq:
-              field: field
-              value: value
-            gt:
-              field: field
-              value: value
-          quota: 0.8008281904610115
-          unfulfilledOnly: true
-          id: 6.027456183070403
-          productQuery:
-            regex:
-              field: field
-              pattern: pattern
-            oneOf:
-              field: field
-              values:
-              - values
-              - values
-            or:
-            - null
-            - null
-            const: true
-            in:
-              field: field
-            and:
-            - null
-            - null
-            lt:
-              field: field
-              value: value
-            eq:
-              field: field
-              value: value
-            gt:
-              field: field
-              value: value
-      properties:
-        data:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.MonitoringScheduleV3'
-      required:
-      - data
-      type: object
-    com.patagona.pricemonitor.share.api.DeleteByNumericIdApiResponse:
-      additionalProperties: false
-      description: Successful delete response.
-      example:
-        data: 0.8008281904610115
-      properties:
-        data:
-          description: numeric id that has been deleted
-          type: number
-      required:
-      - data
-      type: object
-    GetVendorShopMappingsApiResponse:
-      additionalProperties: false
-      example:
-        data:
-        - shops:
-          - domain: domain
-            name: name
-          - domain: domain
-            name: name
-          id: 0.8008281904610115
-          vendorName: vendorName
-        - shops:
-          - domain: domain
-            name: name
-          - domain: domain
-            name: name
-          id: 0.8008281904610115
-          vendorName: vendorName
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.VendorShopMappingV3'
-          type: array
-      required:
-      - data
-      type: object
-    com.patagona.pricemonitor.share.api.PostVendorShopMappingRequestV3:
-      additionalProperties: false
-      description: Request body for creating a vendor and their associated shops.
-      properties:
-        vendorName:
-          description: Vendor name
-          type: string
-        shops:
-          description: List of associated shops
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ShopV3'
-          type: array
-          uniqueItems: true
-      required:
-      - shops
-      - vendorName
-      type: object
-    VendorShopMappingV3ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-          shops:
-          - domain: domain
-            name: name
-          - domain: domain
-            name: name
-          id: 0.8008281904610115
-          vendorName: vendorName
-      properties:
-        data:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.VendorShopMappingV3'
-      required:
-      - data
-      type: object
-    com.patagona.pricemonitor.share.api.PostAccountRequestV3:
-      additionalProperties: false
-      description: A request body that contains information for creation of a new
-        account.
-      properties:
-        name:
-          description: Defines the name of the new user account.
-          type: string
-        email:
-          description: Defines the email of the new user account.
-          type: string
-        password:
-          description: Defines the password for the new user account.
-          type: string
-      required:
-      - email
-      - name
-      - password
-      type: object
-    PostAccountResponseV3ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-          name: name
-          id: 0.8008281904610115
-          email: email
-      properties:
-        data:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostAccountResponseV3'
-      required:
-      - data
-      type: object
-    AmazonBuyboxProductStatsV3ApiResponse:
-      additionalProperties: false
-      example:
-        data:
-        - productId: 0.8008281904610115
-          isInPrimeBuybox: true
-          isInNonPrimeBuybox: true
-        - productId: 0.8008281904610115
-          isInPrimeBuybox: true
-          isInNonPrimeBuybox: true
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.AmazonBuyboxProductStatsV3'
-          type: array
-      required:
-      - data
-      type: object
-    com.patagona.pricemonitor.share.api.PostOfferStatisticsRequestV31:
-      additionalProperties: false
-      description: 'Represents a paginated query with an optional product filter and
-        a specified time range. <br> If no filter is provided, the response will contain
-        all available data, paginated according to the `pagination` parameter. <br>
-        <br> Notes: <br> - At maximum it''s allowed to query 10,000 records (pagination
-        limit). <br> - The maximum time span between the start and end should not
-        exceed 48 hours (timerange limit).'
-      properties:
-        pagination:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Pagination'
-        range:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ZonedTimeRange'
-        filter:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.OneOfProductsQuery'
-      required:
-      - pagination
-      - range
-      type: object
-    com.patagona.pricemonitor.share.api.GetPricingStrategyHistoryResponse:
-      additionalProperties: false
-      description: Version history of all strategies
-      example:
-        history:
-        - documentVersionMessage: documentVersionMessage
-          updateDate: 2000-01-23T04:56:07.000+00:00
-          updatedBy: updatedBy
-          version: version
-          documentVersion: 0
-        - documentVersionMessage: documentVersionMessage
-          updateDate: 2000-01-23T04:56:07.000+00:00
-          updatedBy: updatedBy
-          version: version
-          documentVersion: 0
-      properties:
-        history:
-          description: contains metadata of all strategies
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.StrategyMetadataResponseV3'
-          type: array
-      required:
-      - history
-      type: object
-    com.patagona.pricemonitor.share.api.StrategyMetadataResponseV3:
-      additionalProperties: false
-      description: Metadata used for strategy versioning.
-      example:
-        documentVersionMessage: documentVersionMessage
-        updateDate: 2000-01-23T04:56:07.000+00:00
-        updatedBy: updatedBy
-        version: version
-        documentVersion: 0
-      properties:
-        documentVersion:
-          description: strategy version per contract
-          type: integer
-        documentVersionMessage:
-          description: message provided by user when saving new strategy
-          type: string
-        version:
-          description: schema version of the strategy
-          type: string
-        updateDate:
-          description: timestamp of last strategy update. It needs to be an option
-            to ensure old strategies can be read.
-          format: date-time
-          type: string
-        updatedBy:
-          description: user email of the account that updated the strategy. It needs
-            to be an option to ensure old strategies can be read.
-          type: string
-      required:
-      - documentVersion
-      - version
-      type: object
-    com.patagona.pricemonitor.share.api.ScenarioStrategyMetadataResponse:
-      additionalProperties: false
-      description: Metadata of a scenario strategy in an API response. Here the createdBy/updatedBy
-        fields are e-mails, in [[com.patagona.pricemonitor.share.strategies.ScenarioStrategyMetadata]]
-        these refer to ids
-      example:
-        updateDate: 2000-01-23T04:56:07.000+00:00
-        schemaVersion: 6
-        updatedBy: updatedBy
-        createdBy: createdBy
-        description: description
-        id: 0.8008281904610115
-        creationDate: 2000-01-23T04:56:07.000+00:00
-        title: title
-      properties:
-        description:
-          description: optional description of the scenario
-          type: string
-        id:
-          description: unique identifier of the strategy scenario
-          type: number
-        updateDate:
-          description: timestamp of last strategy update
-          format: date-time
-          type: string
-        createdBy:
-          description: e-mail of the user creating the strategy
-          type: string
-        creationDate:
-          description: timestamp of when the strategy was created
-          format: date-time
-          type: string
-        title:
-          description: up to 50 characters, has to be unique for one contract
-          type: string
-        schemaVersion:
-          description: schema version of the strategy
-          type: integer
-        updatedBy:
-          description: e-mail of the user that last updated the strategy
-          type: string
-      required:
-      - createdBy
-      - creationDate
-      - id
-      - schemaVersion
-      - title
-      - updateDate
-      - updatedBy
-      type: object
-    com.patagona.pricemonitor.share.api.PostScenarioStrategyResponse:
-      additionalProperties: false
-      description: Response of a successful post request
-      example:
-        id: 0.8008281904610115
-      properties:
-        id:
-          description: unique identifier of the strategy scenario
-          type: number
-      required:
-      - id
-      type: object
-    com.patagona.pricemonitor.share.api.GetAllDomainsV3:
-      additionalProperties: false
-      description: Response body containing domain data
-      example:
-        domains:
-        - domain: domain
-          name: name
-          domainId: 0.8008281904610115
-          offerSources:
-          - offerSources
-          - offerSources
-        - domain: domain
-          name: name
-          domainId: 0.8008281904610115
-          offerSources:
-          - offerSources
-          - offerSources
-      properties:
-        domains:
-          description: Sequence of domain data
-          items:
-            $ref: '#/components/schemas/com_patagona_pricemonitor_share_api_GetAllDomainsV3_domains'
-          type: array
-      required:
-      - domains
-      type: object
-    com.patagona.pricemonitor.share.api.PostAdminAddDomainV3:
-      additionalProperties: false
-      description: Response body containing id for the added domain
-      example:
-        domainId: 0.8008281904610115
-      properties:
-        domainId:
-          description: domain id
-          type: number
-      required:
-      - domainId
-      type: object
-    com.patagona.pricemonitor.share.api.ApplicationVersion:
-      additionalProperties: false
-      description: Current api version.
-      example:
-        version: version
-      properties:
-        version:
-          description: version represented as X.Y.Z
-          type: string
-      required:
-      - version
-      type: object
-    com.patagona.pricemonitor.share.api.ApiPriceRecommendation:
-      additionalProperties: false
-      description: Represents a price recommendation of the pricemonitor.
-      example:
-        relativePriceChangePercentage: 3.616076749251911
-        customerProductId: customerProductId
-        gtin: 9.301444243932576
-        productId: productId
-        originalTags:
-        - stringValue: stringValue
-          integerValue: 5
-          booleanValue: true
-          doubleValue: 5.962133916683182
-          label: label
-        - stringValue: stringValue
-          integerValue: 5
-          booleanValue: true
-          doubleValue: 5.962133916683182
-          label: label
-        oldPrice: 0.8008281904610115
-        tags:
-        - stringValue: stringValue
-          integerValue: 5
-          booleanValue: true
-          doubleValue: 5.962133916683182
-          label: label
-        - stringValue: stringValue
-          integerValue: 5
-          booleanValue: true
-          doubleValue: 5.962133916683182
-          label: label
-        originalMaxPriceBoundary: 4.145608029883936
-        newPosition: 2
-        originalMinPriceBoundary: 7.386281948385884
-        oldDeliveryCosts: 1.4658129805029452
-        deliveryCosts: 6.027456183070403
-        price: 2.3021358869347655
-        relevantDomain: relevantDomain
-        currency: currency
-        oldPosition: 7
-        timestamp: 2000-01-23T04:56:07.000+00:00
-      properties:
-        oldPrice:
-          description: The price of the cheapest offer of the own shop(s) on the relevant
-            domain
-          type: number
-        deliveryCosts:
-          description: The delivery costs which were considered for the recommended
-            price
-          type: number
-        timestamp:
-          description: The timestamp when the price recommendation has been calculated
-          format: date-time
-          type: string
-        oldDeliveryCosts:
-          description: The delivery costs corresponding to `oldPrice`
-          type: number
-        tags:
-          description: Additional information on this product
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ExtendedTag'
-          type: array
-        price:
-          description: The recommended price of the relevant domain
-          type: number
-        oldPosition:
-          description: The old position on the relevant domain
-          type: integer
-        gtin:
-          description: GTIN of the product
-          type: number
-        relativePriceChangePercentage:
-          description: Absolute percentage how the recommended price changed compared
-            to the `oldPrice` e.g. 200 stands for 200% which means the recommended
-            price has doubled
-          type: number
-        newPosition:
-          description: The new position on the relevant domain
-          type: integer
-        customerProductId:
-          description: The customer's id of the product
-          type: string
-        originalMaxPriceBoundary:
-          description: Max price boundary during the time when the price was calculated
-          type: number
-        relevantDomain:
-          description: The decisive domain of the price recommendation. It's been
-            determined by the cheapest price recommendation.
-          type: string
-        originalMinPriceBoundary:
-          description: Min price boundary during the time when the price was calculated
-          type: number
-        currency:
-          description: The currency of the price recommendation.
-          type: string
-        productId:
-          description: The internal product id of the pricemonitor
-          type: string
-        originalTags:
-          description: 'List of tags which were set during the time when the price
-            has been calculated. ATTENTION: These are historic tags which are maybe
-            outdated or incomplete.'
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ExtendedTag'
-          type: array
-      required:
-      - currency
-      - originalMaxPriceBoundary
-      - originalMinPriceBoundary
-      - originalTags
-      - price
-      - productId
-      - tags
-      - timestamp
-      type: object
-    com.patagona.pricemonitor.share.api.ExtendedTag:
-      additionalProperties: false
-      description: 'Tags represent additional information of a product. Extended tags
-        can contain evaluated values like numbers which are determined during product
-        import. The `stringValue` is used for deriving the evaluated values. Example:
-        You provide a tag with label "strategy" and `stringValue` "1" during product
-        import. This will be evaluated to these extended values: - integerValue  1
-        - doubleValue   1.0 - booleanValue  true'
-      example:
-        stringValue: stringValue
-        integerValue: 5
-        booleanValue: true
-        doubleValue: 5.962133916683182
-        label: label
-      properties:
-        doubleValue:
-          description: The double value depends on the decimal separator which has
-            been provided during product import.
-          type: number
-        integerValue:
-          description: The integer value of the tag. It's only defined when the `stringValue`
-            consists solely of digits.
-          type: integer
-        label:
-          description: The name of the tag. It can't be empty.
-          type: string
-        stringValue:
-          description: The text value of the tag.
-          type: string
-        booleanValue:
-          description: The boolean value of the tag. It's only set to true when the
-            `stringValue` is "1" or "true".
-          type: boolean
-      required:
-      - label
-      - stringValue
-      type: object
-    com.patagona.pricemonitor.share.api.PaginationResponse:
-      additionalProperties: false
-      description: This model describes the information passed to the user for a paginated
-        request.
-      example:
-        totalSize: 1
-        start: 1
-        limit: 1
-        nextUrl: nextUrl
-      properties:
-        nextUrl:
-          description: the url that can be called to retrieve the next page, None
-            if th last page has been requested
-          type: string
-        totalSize:
-          description: the total number of elements that is paginated over
-          type: integer
-        start:
-          description: the start index of the currently requested page
-          type: integer
-        limit:
-          description: the number of elements in a full page
-          type: integer
-      required:
-      - limit
-      - start
-      - totalSize
-      type: object
-    ProductAndOffers_2:
-      example:
-        offers:
-        - ignored: true
-          gtin: 6
-          productId: productId
-          retrievalDate: 2000-01-23T04:56:07.000+00:00
-          availability: true
-          creationDate: 2000-01-23T04:56:07.000+00:00
-          vendorName: vendorName
-          positionByTotalPrice: 2
-          productName: productName
-          url: url
-          minDeliveryTime: 5
-          vendorDomainId: vendorDomainId
-          deliveryCosts: 0.8008281904610115
-          maxDeliveryTime: 1
-          price: 7.061401241503109
-          domain: domain
-          contractId: contractId
-          attributes:
-          - name: name
-            value: value
-          - name: name
-            value: value
-          currency: currency
-          positionByUnitPrice: 5
-        - ignored: true
-          gtin: 6
-          productId: productId
-          retrievalDate: 2000-01-23T04:56:07.000+00:00
-          availability: true
-          creationDate: 2000-01-23T04:56:07.000+00:00
-          vendorName: vendorName
-          positionByTotalPrice: 2
-          productName: productName
-          url: url
-          minDeliveryTime: 5
-          vendorDomainId: vendorDomainId
-          deliveryCosts: 0.8008281904610115
-          maxDeliveryTime: 1
-          price: 7.061401241503109
-          domain: domain
-          contractId: contractId
-          attributes:
-          - name: name
-            value: value
-          - name: name
-            value: value
-          currency: currency
-          positionByUnitPrice: 5
-        product:
-          customerProductId: customerProductId
-          gtin: 9
-          referencePrice: 4.145608029883936
-          maxPriceBoundary: 3.616076749251911
-          name: name
-          id: id
-          minPriceBoundary: 2.027123023002322
-          tags:
-          - value: value
-            key: key
-          - value: value
-            key: key
-      properties:
-        offers:
-          items:
-            $ref: '#/components/schemas/ApiOffer'
-          type: array
-        product:
-          $ref: '#/components/schemas/ApiProduct'
-      type: object
-    com.patagona.pricemonitor.share.api.GetShopsByDomainResponseV3:
-      additionalProperties: false
-      description: Describes a domain and its corresponding shops
-      example:
-        domain: domain
-        shops:
-        - shops
-        - shops
-      properties:
-        domain:
-          description: domain name
-          type: string
-        shops:
-          description: shop names which have offers in the domain for a given time
-            range
-          items:
-            type: string
-          type: array
-          uniqueItems: true
-      required:
-      - domain
-      - shops
-      type: object
+        - name
+        - value
     com.patagona.pricemonitor.share.api.ApiOffer:
-      additionalProperties: false
-      example:
-        ignored: true
-        gtin: 2.3021358869347655
-        productId: productId
-        retrievalDate: 2000-01-23T04:56:07.000+00:00
-        availability: true
-        vendorName: vendorName
-        creationDate: 2000-01-23T04:56:07.000+00:00
-        positionByTotalPrice: 0
-        url: url
-        productName: productName
-        minDeliveryTime: 5
-        vendorDomainId: vendorDomainId
-        deliveryCosts: 6.027456183070403
-        maxDeliveryTime: 1
-        price: 5.962133916683182
-        domain: domain
-        attributes:
-        - name: name
-          value: value
-        - name: name
-          value: value
-        currency: currency
-        positionByUnitPrice: 7
       properties:
         positionByTotalPrice:
           type: integer
@@ -14093,17 +8392,17 @@ components:
         availability:
           type: boolean
         attributes:
+          type: array
           items:
             $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.OfferAttribute'
-          type: array
         vendorName:
           type: string
         retrievalDate:
-          format: date-time
           type: string
+          format: date-time
         creationDate:
-          format: date-time
           type: string
+          format: date-time
         productName:
           type: string
         currency:
@@ -14112,602 +8411,1406 @@ components:
           type: string
         ignored:
           type: boolean
-      required:
-      - attributes
-      - creationDate
-      - currency
-      - deliveryCosts
-      - domain
-      - ignored
-      - positionByTotalPrice
-      - positionByUnitPrice
-      - price
-      - productId
-      - productName
-      - url
-      - vendorName
-      type: object
-    com.patagona.pricemonitor.share.api.OfferAttribute:
       additionalProperties: false
-      description: Created by Andreas Frankenberger on 28.01.16.
-      example:
-        name: name
-        value: value
-      properties:
-        name:
-          type: string
-        value:
-          type: string
-      required:
-      - name
-      - value
       type: object
-    com.patagona.pricemonitor.share.api.PostOfferStatisticsResponseV31:
-      additionalProperties: false
-      description: Represents aggregated offer statistics for a single product.
-      example:
-        productId: productId
-        offerCount: 0
-        stats:
-          unitPriceStats:
-            min: 6.027456183070403
-            avg: 1.4658129805029452
-            max: 5.962133916683182
-          domainStats:
-          - competitorOfferCount: 5
-            domain: domain
-          - competitorOfferCount: 5
-            domain: domain
-          totalPriceStats:
-            min: 6.027456183070403
-            avg: 1.4658129805029452
-            max: 5.962133916683182
-      properties:
-        productId:
-          description: Pricemonitor's internal unique product identifier.
-          type: string
-        offerCount:
-          description: The number of offers found on all domains for the product.
-          type: integer
-        stats:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ProductOfferStatisticsV31'
       required:
-      - offerCount
-      - productId
-      - stats
+        - productName
+        - ignored
+        - url
+        - attributes
+        - positionByUnitPrice
+        - vendorName
+        - productId
+        - price
+        - deliveryCosts
+        - creationDate
+        - currency
+        - positionByTotalPrice
+        - domain
+    QueryOffersOfShopV3ApiResponse:
+      required:
+        - data
       type: object
-    com.patagona.pricemonitor.share.api.ProductOfferStatisticsV31:
       additionalProperties: false
-      description: Contains details on both unit price and total price statistics
-        of product offers.
-      example:
-        unitPriceStats:
-          min: 6.027456183070403
-          avg: 1.4658129805029452
-          max: 5.962133916683182
-        domainStats:
-        - competitorOfferCount: 5
-          domain: domain
-        - competitorOfferCount: 5
-          domain: domain
-        totalPriceStats:
-          min: 6.027456183070403
-          avg: 1.4658129805029452
-          max: 5.962133916683182
+      description: ''
       properties:
-        unitPriceStats:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PriceStatisticsV31'
-        totalPriceStats:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PriceStatisticsV31'
-        domainStats:
-          description: A list of offer statistics per domain. Domains without competitor
-            offers are not included in the list.
+        data:
           items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.DomainOfferStatisticsV31'
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiOffer'
           type: array
-      required:
-      - domainStats
-      - totalPriceStats
-      - unitPriceStats
-      type: object
-    com.patagona.pricemonitor.share.api.PriceStatisticsV31:
-      additionalProperties: false
-      description: 'Represents basic price statistics: (min, avg, max). All prices
-        are rounded half-up to two decimal places.'
-      example:
-        min: 6.027456183070403
-        avg: 1.4658129805029452
-        max: 5.962133916683182
+    com.patagona.pricemonitor.share.api.Pagination:
+      description: This model describes a step in a paginated endpoint. It consists of the start index, set to 0 for the first page. The next page starts at (previous start) + limit. Reasonable values for the limit parameter depend on the specific endpoint.
       properties:
-        min:
-          description: The minimum offer price.
-          type: number
-        avg:
-          description: The average offer price.
-          type: number
-        max:
-          description: The maximum offer price.
-          type: number
-      required:
-      - avg
-      - max
-      - min
-      type: object
-    com.patagona.pricemonitor.share.api.DomainOfferStatisticsV31:
-      additionalProperties: false
-      description: Represents statistics about offers from competitors for a specific
-        domain. The competitor offers are determined under-the-hood by excluding offers
-        of the registered own shops.
-      example:
-        competitorOfferCount: 5
-        domain: domain
-      properties:
-        domain:
-          description: This field specifies the domain where the competitor offers
-            are sourced from. It's a string representing the domain name, such as
-            "google.de".
-          type: string
-        competitorOfferCount:
-          description: The number of competitor offers available in the specified
-            domain.
+        start:
           type: integer
-      required:
-      - competitorOfferCount
-      - domain
-      type: object
-    com.patagona.pricemonitor.share.api.GetOfferStatisticsV3:
+          description: ''
+        limit:
+          type: integer
+          description: ''
       additionalProperties: false
-      description: Offer statistics of a product.
-      example:
-        productId: productId
-        statsByDomain:
-        - offerCount: 0
-          domain: domain
-          minPrice: 6.027456183070403
-          averagePrice: 1.4658129805029452
-        - offerCount: 0
-          domain: domain
-          minPrice: 6.027456183070403
-          averagePrice: 1.4658129805029452
+      type: object
+      required:
+        - start
+        - limit
+    com.patagona.pricemonitor.share.api.ZonedTimeRange:
+      description: Represents a time range. It's required that the end timestamp is after or equals the start timestamp.
       properties:
-        productId:
-          description: Internal product identifier.
+        start:
           type: string
-        statsByDomain:
-          description: List of offer statistics per domain
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.OfferStatsPerDomain'
+          format: date-time
+          description: The starting point of the time range, represented as a timestamp in ISO 8601 format (e.g., "2023-10-19T13:45:30Z") in UTC.
+        end:
+          type: string
+          format: date-time
+          description: The ending point of the time range, represented as a timestamp in ISO 8601 format (e.g., "2023-10-19T14:45:30Z") in UTC.
+      additionalProperties: false
+      type: object
+      required:
+        - start
+        - end
+    com.patagona.pricemonitor.share.api.ProductIdQuery:
+      description: This product query evaluates to 'true' if the value of the 'field' is one on the specified 'values'.
+      properties:
+        field:
+          type: string
+          description: 'Specifies the attribute to filter by. It accepts two values: <br> - "customerProductId": Your unique identifier for the product. <br> - "productId": Patagona''s internal product id (must be a numerical integer).'
+        values:
           type: array
-      required:
-      - productId
-      - statsByDomain
-      type: object
-    com.patagona.pricemonitor.share.api.OfferStatsPerDomain:
-      additionalProperties: false
-      description: Offer statistics per domain.
-      example:
-        offerCount: 0
-        domain: domain
-        minPrice: 6.027456183070403
-        averagePrice: 1.4658129805029452
-      properties:
-        domain:
-          description: Domain name
-          type: string
-        offerCount:
-          description: Number of offers
-          type: integer
-        minPrice:
-          description: Minimum price, rounded to two decimal places, in a set of offers.
-          type: number
-        averagePrice:
-          description: Average price, rounded to two decimal places, in a set of offers.
-          type: number
-      required:
-      - averagePrice
-      - domain
-      - minPrice
-      - offerCount
-      type: object
-    com.patagona.pricemonitor.share.api.PriceDumpingStatsResponse:
-      additionalProperties: false
-      example:
-        statsOverAllomains:
-          potentiallyInitiatedPriceDumpings: 5
-          uniqueProductInitiatedPriceDumpings: 6
-          productsAtMinPrice: 0
-          uniqueProductPotentiallyInitiatedPriceDumpings: 1
-          initiatedPriceDumpings: 5
-        statsPerDomain:
-        - domain: domain
-          productPriceDumpingStats:
-            potentiallyInitiatedPriceDumpings: 5
-            uniqueProductInitiatedPriceDumpings: 6
-            productsAtMinPrice: 0
-            uniqueProductPotentiallyInitiatedPriceDumpings: 1
-            initiatedPriceDumpings: 5
-        - domain: domain
-          productPriceDumpingStats:
-            potentiallyInitiatedPriceDumpings: 5
-            uniqueProductInitiatedPriceDumpings: 6
-            productsAtMinPrice: 0
-            uniqueProductPotentiallyInitiatedPriceDumpings: 1
-            initiatedPriceDumpings: 5
-      properties:
-        statsPerDomain:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.DomainPriceDumpingStats'
-          type: array
-        statsOverAllomains:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ProductPriceDumpingStats'
-      required:
-      - statsOverAllomains
-      - statsPerDomain
-      type: object
-    com.patagona.pricemonitor.share.api.DomainPriceDumpingStats:
-      additionalProperties: false
-      description: This class contains the price dumping statistic for a single domain.
-        A price dumping event exists if a vendor reduces the price below the minimum
-        price at the previous timestamp while also selling the product at the new
-        minimum price.
-      example:
-        domain: domain
-        productPriceDumpingStats:
-          potentiallyInitiatedPriceDumpings: 5
-          uniqueProductInitiatedPriceDumpings: 6
-          productsAtMinPrice: 0
-          uniqueProductPotentiallyInitiatedPriceDumpings: 1
-          initiatedPriceDumpings: 5
-      properties:
-        domain:
-          type: string
-        productPriceDumpingStats:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ProductPriceDumpingStats'
-      required:
-      - domain
-      - productPriceDumpingStats
-      type: object
-    com.patagona.pricemonitor.share.api.ProductPriceDumpingStats:
-      additionalProperties: false
-      description: This class contains the number of price dumping events. The counts
-        prefixed with "uniqueProduct" only count the events once per product, the
-        non prefixed counts count every event. If we are unable to detect which vendor
-        reduced the price first, because we only sampled the price when multiple vendors
-        are at the same price, those events are counted in the fields infixed with
-        "potetially".
-      example:
-        potentiallyInitiatedPriceDumpings: 5
-        uniqueProductInitiatedPriceDumpings: 6
-        productsAtMinPrice: 0
-        uniqueProductPotentiallyInitiatedPriceDumpings: 1
-        initiatedPriceDumpings: 5
-      properties:
-        productsAtMinPrice:
-          description: This field denotes the number of products at the min price
-            from the queried vendors, at the respective newest timestamp per domain
-            and product.
-          type: integer
-        uniqueProductInitiatedPriceDumpings:
-          type: integer
-        uniqueProductPotentiallyInitiatedPriceDumpings:
-          type: integer
-        initiatedPriceDumpings:
-          type: integer
-        potentiallyInitiatedPriceDumpings:
-          type: integer
-      required:
-      - initiatedPriceDumpings
-      - potentiallyInitiatedPriceDumpings
-      - productsAtMinPrice
-      - uniqueProductInitiatedPriceDumpings
-      - uniqueProductPotentiallyInitiatedPriceDumpings
-      type: object
-    com.patagona.pricemonitor.share.api.PutItemsResponseV3:
-      additionalProperties: false
-      description: Represents list of unique identifiers
-      example:
-        ids:
-        - ids
-        - ids
-      properties:
-        ids:
-          description: list of ids of the items that have been saved or updated
           items:
             type: string
-          type: array
-      required:
-      - ids
-      type: object
-    com.patagona.pricemonitor.share.api.PostOrderStatisticsResponseV3:
+          description: An array of strings containing the ids of the products to be queried.
       additionalProperties: false
-      description: Represents aggregated order statistics for a single product.
-      example:
-        itemId: itemId
-        productId: productId
-        numberOfSoldItems: 0
+      type: object
+      required:
+        - field
+        - values
+    com.patagona.pricemonitor.share.api.OneOfProductsQuery:
+      description: An optional parameter to further filter the data based on product criteria.
+      properties:
+        oneOf:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ProductIdQuery'
+          description: The 'oneOf' represents a product query.
+      additionalProperties: false
+      type: object
+      required:
+        - oneOf
+    com.patagona.pricemonitor.share.api.PostOfferStatisticsRequestV31:
+      description: 'Represents a paginated query with an optional product filter and a specified time range. <br> If no filter is provided, the response will contain all available data, paginated according to the `pagination` parameter. <br> <br> Notes: <br> - At maximum it''s allowed to query 10,000 records (pagination limit). <br> - The maximum time span between the start and end should not exceed 48 hours (timerange limit).'
+      properties:
+        pagination:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Pagination'
+          description: Specifies the pagination details such as the start index and the number of records to fetch (limit). At maximum it's allowed to query 10,000 records.
+        range:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ZonedTimeRange'
+          description: 'Defines the time range for which offer statistics are queried. Note: The maximum time span between the start and end should not exceed 48 hours.'
+        filter:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.OneOfProductsQuery'
+          description: An optional parameter to further filter the data based on product criteria.
+      additionalProperties: false
+      type: object
+      required:
+        - pagination
+        - range
+    com.patagona.pricemonitor.share.api.PriceStatisticsV31:
+      description: 'Represents basic price statistics: (min, avg, max). All prices are rounded half-up to two decimal places.'
+      properties:
+        min:
+          type: number
+          description: The minimum offer price.
+        avg:
+          type: number
+          description: The average offer price.
+        max:
+          type: number
+          description: The maximum offer price.
+      additionalProperties: false
+      type: object
+      required:
+        - min
+        - avg
+        - max
+    com.patagona.pricemonitor.share.api.DomainOfferStatisticsV31:
+      description: Represents statistics about offers from competitors for a specific domain. The competitor offers are determined under-the-hood by excluding offers of the registered own shops.
+      properties:
+        domain:
+          type: string
+          description: This field specifies the domain where the competitor offers are sourced from. It's a string representing the domain name, such as "google.de".
+        competitorOfferCount:
+          type: integer
+          description: The number of competitor offers available in the specified domain.
+      additionalProperties: false
+      type: object
+      required:
+        - domain
+        - competitorOfferCount
+    com.patagona.pricemonitor.share.api.ProductOfferStatisticsV31:
+      description: Contains details on both unit price and total price statistics of product offers.
+      properties:
+        unitPriceStats:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PriceStatisticsV31'
+          description: Offer statistics considering the unit price.
+        totalPriceStats:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PriceStatisticsV31'
+          description: Offer statistics considering the unit price plus delivery costs.
+        domainStats:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.DomainOfferStatisticsV31'
+          description: A list of offer statistics per domain. Domains without competitor offers are not included in the list.
+      additionalProperties: false
+      type: object
+      required:
+        - unitPriceStats
+        - totalPriceStats
+        - domainStats
+    com.patagona.pricemonitor.share.api.PostOfferStatisticsResponseV31:
+      description: Represents aggregated offer statistics for a single product.
       properties:
         productId:
+          type: string
           description: Pricemonitor's internal unique product identifier.
-          type: string
-        itemId:
-          description: The unique identifier of the sold item, expected to align with
-            the customerProductId.
-          type: string
-        numberOfSoldItems:
-          description: The total count of how often the product has been sold.
+        offerCount:
           type: integer
-      required:
-      - itemId
-      - numberOfSoldItems
-      - productId
-      type: object
-    com.patagona.pricemonitor.share.api.GetContractResponseV3:
+          description: The number of offers found on all domains for the product.
+        stats:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ProductOfferStatisticsV31'
+          description: The aggregated offer price statistics for the product.
       additionalProperties: false
-      description: Contract information
-      example:
-        companyId: 0.8008281904610115
-        description: description
-        active: true
-        creationDate: 2000-01-23T04:56:07.000+00:00
-        expirationDate: 2000-01-23T04:56:07.000+00:00
-        sid: sid
+      type: object
+      required:
+        - productId
+        - offerCount
+        - stats
+    QueryOfferStatisticsV31ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostOfferStatisticsResponseV31'
+          type: array
+    com.patagona.pricemonitor.share.api.OfferStatsPerDomain:
+      description: Offer statistics per domain.
+      properties:
+        domain:
+          type: string
+          description: Domain name
+        offerCount:
+          type: integer
+          description: Number of offers
+        minPrice:
+          type: number
+          description: Minimum price, rounded to two decimal places, in a set of offers.
+        averagePrice:
+          type: number
+          description: Average price, rounded to two decimal places, in a set of offers.
+      additionalProperties: false
+      type: object
+      required:
+        - domain
+        - offerCount
+        - minPrice
+        - averagePrice
+    com.patagona.pricemonitor.share.api.GetOfferStatisticsV3:
+      description: Offer statistics of a product.
+      properties:
+        productId:
+          type: string
+          description: Internal product identifier.
+        statsByDomain:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.OfferStatsPerDomain'
+          description: List of offer statistics per domain
+      additionalProperties: false
+      type: object
+      required:
+        - productId
+        - statsByDomain
+    GetOfferStatisticsV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.GetOfferStatisticsV3'
+          type: array
+    PutProductsApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          $ref: '#/components/schemas/Task'
+    QueryOffersApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/ApiOffer'
+          type: array
+    com.patagona.pricemonitor.share.api.ShopV3:
+      description: A shop, in terms of online shop, sells his products on a certain domain.
+      properties:
+        domain:
+          type: string
+          description: Domain name
+        name:
+          type: string
+          description: Shop name on given domain.
+      additionalProperties: false
+      type: object
+      required:
+        - domain
+        - name
+    com.patagona.pricemonitor.share.api.PriceDumpingStatsRequest:
+      description: A request for price dumping statistics for the given shops.
+      properties:
+        startDate:
+          type: string
+          format: date-time
+          description: Start of the timerange in which we search for price dumping events
+        endDate:
+          type: string
+          format: date-time
+          description: End of the timerange in which we search for price dumping events
+        includeDeliveryCosts:
+          type: boolean
+          description: Indicates if we consider price + delivery cost to detect price changes or only price
+        shops:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ShopV3'
+          uniqueItems: true
+          description: Specifies for which shops we detect price dumping events
+      additionalProperties: false
+      type: object
+      required:
+        - startDate
+        - endDate
+        - includeDeliveryCosts
+        - shops
+    com.patagona.pricemonitor.share.api.ProductPriceDumpingStats:
+      description: This class contains the number of price dumping events. The counts prefixed with "uniqueProduct" only count the events once per product, the non prefixed counts count every event. If we are unable to detect which vendor reduced the price first, because we only sampled the price when multiple vendors are at the same price, those events are counted in the fields infixed with "potetially".
+      properties:
+        productsAtMinPrice:
+          type: integer
+          description: This field denotes the number of products at the min price from the queried vendors, at the respective newest timestamp per domain and product.
+        uniqueProductInitiatedPriceDumpings:
+          type: integer
+          description: ''
+        uniqueProductPotentiallyInitiatedPriceDumpings:
+          type: integer
+          description: ''
+        initiatedPriceDumpings:
+          type: integer
+          description: ''
+        potentiallyInitiatedPriceDumpings:
+          type: integer
+          description: ''
+      additionalProperties: false
+      type: object
+      required:
+        - initiatedPriceDumpings
+        - uniqueProductInitiatedPriceDumpings
+        - uniqueProductPotentiallyInitiatedPriceDumpings
+        - productsAtMinPrice
+        - potentiallyInitiatedPriceDumpings
+    com.patagona.pricemonitor.share.api.DomainPriceDumpingStats:
+      description: This class contains the price dumping statistic for a single domain. A price dumping event exists if a vendor reduces the price below the minimum price at the previous timestamp while also selling the product at the new minimum price.
+      properties:
+        domain:
+          type: string
+          description: ''
+        productPriceDumpingStats:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ProductPriceDumpingStats'
+          description: ''
+      additionalProperties: false
+      type: object
+      required:
+        - domain
+        - productPriceDumpingStats
+    com.patagona.pricemonitor.share.api.PriceDumpingStatsResponse:
+      properties:
+        statsPerDomain:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.DomainPriceDumpingStats'
+          description: ''
+        statsOverAllomains:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ProductPriceDumpingStats'
+          description: ''
+      additionalProperties: false
+      type: object
+      required:
+        - statsPerDomain
+        - statsOverAllomains
+    QueryPriceDumpingStatsApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PriceDumpingStatsResponse'
+    com.patagona.pricemonitor.share.api.CustomerOrderV3:
+      description: An order placed in a shop.
+      properties:
+        shippingCosts:
+          type: number
+          description: Shipping costs of the order
+        orderId:
+          type: string
+          description: Unique id of an order. It must mean unique in the contract, not in the pricemonitor.
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CustomerOrderItemV2'
+          description: List of bought items
+        totalPrice:
+          type: number
+          description: Total price of the order
+        origin:
+          type: string
+          description: Origin of an order, e.g. the online shop where the order is placed
+        creationDate:
+          type: string
+          format: date-time
+          description: Date when the order is created
+        currency:
+          type: string
+          description: 'Currency used in the order. ISO 4217 Currency Codes: e.g. EUR'
+        referrer:
+          type: string
+          description: Referrer of an order. Third party (e.g. marketplace) which referred the customer to the online shop
+      additionalProperties: false
+      type: object
+      required:
+        - orderId
+        - shippingCosts
+        - origin
+        - creationDate
+        - items
+        - totalPrice
+        - currency
+    com.patagona.pricemonitor.share.api.PutCustomerOrdersRequestV3:
+      description: Request body containing bulked orders
+      properties:
+        orders:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CustomerOrderV3'
+          description: List of orders
+        version:
+          type: string
+          description: Version of orders. Currently only "3" is allowed
+      additionalProperties: false
+      type: object
+      required:
+        - orders
+        - version
+    com.patagona.pricemonitor.share.api.PutItemsResponseV3:
+      description: Represents list of unique identifiers
+      properties:
+        ids:
+          type: array
+          items:
+            type: string
+          description: list of ids of the items that have been saved or updated
+      additionalProperties: false
+      type: object
+      required:
+        - ids
+    PutItemsV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PutItemsResponseV3'
+    DeletedItemsApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          $ref: '#/components/schemas/DeletedItemsResponse'
+    com.patagona.pricemonitor.share.api.PostOrderStatisticsRequestV3:
+      description: 'Represents a paginated query with an optional product filter and a specified time range. <br> If no filter is provided, the response will contain all available data, paginated according to the `pagination` parameter. <br> <br> Notes: <br> - At maximum it''s allowed to query 10,000 records (pagination limit). <br> - The maximum time span between the start and end should not exceed 30 days (timerange limit).'
+      properties:
+        pagination:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Pagination'
+          description: Specifies the pagination details such as the start index and the number of records to fetch (limit). At maximum it's allowed to query 10,000 records.
+        range:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ZonedTimeRange'
+          description: 'Defines the time range for which order statistics are queried. Note: The maximum time span between the start and end should not exceed 30 days.'
+        filter:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.OneOfProductsQuery'
+          description: An optional parameter to further filter the data based on product criteria.
+      additionalProperties: false
+      type: object
+      required:
+        - pagination
+        - range
+    com.patagona.pricemonitor.share.api.PostOrderStatisticsResponseV3:
+      description: Represents aggregated order statistics for a single product.
+      properties:
+        productId:
+          type: string
+          description: Pricemonitor's internal unique product identifier.
+        itemId:
+          type: string
+          description: The unique identifier of the sold item, expected to align with the customerProductId.
+        numberOfSoldItems:
+          type: integer
+          description: The total count of how often the product has been sold.
+      additionalProperties: false
+      type: object
+      required:
+        - productId
+        - itemId
+        - numberOfSoldItems
+    QueryOrderStatisticsV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostOrderStatisticsResponseV3'
+          type: array
+    com.patagona.pricemonitor.share.api.DeleteOrderQueryV3:
+      description: Query to specify the order to be deleted
+      properties:
+        orderId:
+          type: string
+          description: Unique identifier of the order
+        creationDate:
+          type: string
+          format: date-time
+          description: Creation date of the corresponding order. It is a Timestamp in UTC time zone
+      additionalProperties: false
+      type: object
+      required:
+        - orderId
+        - creationDate
+    com.patagona.pricemonitor.share.api.DeleteOrdersByQueryRequestV3:
+      description: 'Request to delete a list of customer orders by providing an order query Notes: <br> - At maximum it''s allowed to provide 10,000 order queries per request. <br>'
+      properties:
+        orders:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.DeleteOrderQueryV3'
+          description: List of order queries, each query should include an order id and its corresponding creation date
+      additionalProperties: false
+      type: object
+      required:
+        - orders
+    GetExtendedTagsApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/ExtendedTag'
+          type: array
+    com.patagona.pricemonitor.share.api.ContractType:
+      type: string
+      enum:
+        - Pricemonitor for manufacturers
+        - Pricemonitor for resellers
+    com.patagona.pricemonitor.share.api.AdminContractV2:
+      description: A contract used for data representation in the admin-endpoint
       properties:
         expirationDate:
-          description: The date when contract will expire.
-          format: date-time
           type: string
+          format: date-time
+          description: The date and time the contract expires
         description:
-          description: The description for the given contract provided by the end-user.
           type: string
-        contractType:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ContractType'
+          description: The contract's description
+        id:
+          type: string
+          description: The id of the contract
         creationDate:
-          description: The creation date of the contract.
+          type: string
           format: date-time
-          type: string
-        sid:
-          description: Unique string id of the contract in pricemonitor.
-          type: string
-        companyId:
-          description: The id of the company, in pricemonitor, to which contract belongs
-            to.
-          type: number
+          description: The date and time the contract was created
+        type:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ContractType'
         active:
-          description: Indicates if the contract is active or disabled.
           type: boolean
-      required:
-      - active
-      - companyId
-      - contractType
-      - creationDate
-      - description
-      - sid
-      type: object
-    com.patagona.pricemonitor.share.api.ApiProduct:
+          description: The contract-status
       additionalProperties: false
-      description: A product in the pricemonitor.
-      example:
-        customerProductId: customerProductId
-        gtin: 6.027456183070403
-        referencePrice: 5.962133916683182
-        maxPriceBoundary: 1.4658129805029452
-        name: name
-        id: id
-        minPriceBoundary: 0.8008281904610115
-        tags:
-        - value: value
-          key: key
-        - value: value
-          key: key
+      type: object
+      required:
+        - description
+        - active
+        - id
+        - creationDate
+        - type
+    com.patagona.pricemonitor.share.api.AdminCompanyV2:
+      description: A company with its contracts used for data representation in the admin-endpoint
+      properties:
+        id:
+          type: number
+          description: The id of the company
+        name:
+          type: string
+          description: The company's name
+        contracts:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.AdminContractV2'
+          description: A list of the comapny's contracts
+      additionalProperties: false
+      type: object
+      required:
+        - id
+        - name
+        - contracts
+    com.patagona.pricemonitor.share.api.ContractFeatures:
+      properties:
+        disabled:
+          type: array
+          items:
+            type: string
+        enabled:
+          type: array
+          items:
+            type: string
+      additionalProperties: false
+      type: object
+      required:
+        - disabled
+        - enabled
+    com.patagona.pricemonitor.share.api.GetContractSettingsResponseV1:
       properties:
         name:
-          description: Name of the product.
           type: string
-        tags:
-          description: Additional information on this product.
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Tag'
+          description: ''
+        expirationDate:
+          type: string
+          format: date-time
+          description: ''
+        portals:
           type: array
-        minPriceBoundary:
-          description: Maximum price which pricemonitor can recommend for the product.
-            It won't recommend any price above this boundary.
-          type: number
-        gtin:
-          description: GTIN of the product. Can be optionally.
-          type: number
-        customerProductId:
-          description: The customer's id of the product. This field allows to link
-            products in pricemonitor to products in the customer's system.
+          items:
+            type: string
+          description: ''
+        includeDeliveryCosts:
+          type: boolean
+          description: ''
+        features:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ContractFeatures'
+          description: ''
+        imageTag:
           type: string
+          description: The name of the tag that contains the product image url
+        company:
+          type: string
+          description: ''
         id:
-          description: Id of the product in the pricemonitor.
+          type: number
+          description: ''
+        monitoringPriority:
+          type: integer
+          description: Priority of the contract in the monitoring queue
+        currency:
           type: string
-        maxPriceBoundary:
-          description: Minimum price which pricemonitor can recommend for the product.
-            It won't recommend any price below this boundary.
-          type: number
-        referencePrice:
-          description: Some price that will be used as benchmark for certain components
-            in pricemonitor.
-          type: number
-      required:
-      - id
-      - name
-      - referencePrice
-      - tags
-      type: object
-    com.patagona.pricemonitor.share.api.Tag:
+          description: The contract's currency as three letter code
+        type:
+          type: string
+        sid:
+          type: string
+          description: ''
+        msrpTag:
+          type: string
+          description: The name of the tag that contains the manufacturers suggested retail price
+        mapTag:
+          type: string
+          description: The name of the tag that contains the minimum advertised price
+        active:
+          type: boolean
+          description: ''
       additionalProperties: false
-      example:
-        value: value
-        key: key
+      type: object
+      required:
+        - monitoringPriority
+        - active
+        - sid
+        - company
+        - features
+        - portals
+        - id
+        - name
+        - includeDeliveryCosts
+        - type
+        - currency
+    com.patagona.pricemonitor.share.api.PutAdminContractSettingsBody:
+      properties:
+        name:
+          type: string
+        expirationDate:
+          type: string
+          format: date-time
+        portals:
+          type: array
+          items:
+            type: string
+        features:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ContractFeatures'
+        id:
+          type: number
+        monitoringPriority:
+          type: integer
+        type:
+          type: string
+        sid:
+          type: string
+        active:
+          type: boolean
+      additionalProperties: false
+      type: object
+      required:
+        - active
+        - sid
+        - features
+        - portals
+        - id
+        - name
+        - type
+    com.patagona.pricemonitor.share.api.ContractStats:
+      description: Contract statistics
+      properties:
+        productCount:
+          type: integer
+          description: The count of currently monitored products
+        portalCount:
+          type: integer
+          description: The number of actively monitored domains
+        allOfferCount:
+          type: number
+          description: The number of offers found for the monitored products without any filters applied
+        offerCount:
+          type: number
+          description: The number of offers found for the monitored products after filtering
+        vendorCount:
+          type: number
+          description: The count of vendors found for the monitored products
+      additionalProperties: false
+      type: object
+      required:
+        - portalCount
+        - offerCount
+        - allOfferCount
+        - vendorCount
+        - productCount
+    com.patagona.pricemonitor.share.api.OfferSelector:
+      description: Whitelist entry for offers based on different attributes.
+      properties:
+        domain:
+          type: string
+          description: The domain
+        vendorName:
+          type: string
+          description: The vendor name
+        productName:
+          type: string
+          description: The product name
+      additionalProperties: false
+      type: object
+      required:
+        - domain
+        - vendorName
+        - productName
+    com.patagona.pricemonitor.share.api.PricesByDayByProductIdRequestV2:
+      description: A request for all known prices for a given day & product ID. Provides the option to filter the results using the `offerSelectors`.
+      properties:
+        day:
+          type: string
+          format: date-time
+          description: The day for which to return the prices in ISO 8601
+        offers:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.OfferSelector'
+          description: A list of `OfferSelector`s that allows filtering down the results. The selectors are combined using an OR operation. The list must contain at least one element.
+      additionalProperties: false
+      type: object
+      required:
+        - day
+        - offers
+    com.patagona.pricemonitor.share.api.PricesByDayByProductIdResponsePricePointV2:
+      description: A single price point of a product
+      properties:
+        price:
+          type: number
+          description: The price
+        deliveryCosts:
+          type: number
+          description: The delivery costs
+        timestamp:
+          type: string
+          format: date-time
+          description: The timestamp of when the price was found
+      additionalProperties: false
+      type: object
+      required:
+        - price
+        - deliveryCosts
+        - timestamp
+    com.patagona.pricemonitor.share.api.PricesByDayByProductIdResponseV2:
+      description: Contains all known prices for a given day & product ID for one domain & vendor combination.
+      properties:
+        domain:
+          type: string
+          description: The domain these prices were found on
+        vendorName:
+          type: string
+          description: The name of the vendor these prices were found for
+        productName:
+          type: string
+          description: The name of the product the vendor is using
+        prices:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PricesByDayByProductIdResponsePricePointV2'
+          description: A list of `PricesByDayByProductIdResponsePricePointV2` elements containing the prices
+      additionalProperties: false
+      type: object
+      required:
+        - domain
+        - vendorName
+        - productName
+        - prices
+    com.patagona.pricemonitor.share.api.TagFilteredVendorsRequest:
+      properties:
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          description: A list of key value pairs of product tags
+      additionalProperties: false
+      type: object
+      required: []
+    com.patagona.pricemonitor.share.api.ResellerSummaryByDomain:
+      properties:
+        averageDiscount:
+          type: number
+        averagePosition:
+          type: number
+        productsUnderReferencePrice:
+          type: number
+        portalName:
+          type: string
+        productsCount:
+          type: number
+        resellerName:
+          type: string
+        minPriceCount:
+          type: number
+      additionalProperties: false
+      type: object
+      required:
+        - portalName
+        - averageDiscount
+        - productsCount
+        - minPriceCount
+        - resellerName
+        - productsUnderReferencePrice
+        - averagePosition
+    com.patagona.pricemonitor.share.api.PostVendorsByDomainResponse:
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ResellerSummaryByDomain'
+        totalCount:
+          type: integer
+      additionalProperties: false
+      type: object
+      required:
+        - data
+        - totalCount
+    com.patagona.pricemonitor.share.api.ApiOfferAttributeV2:
+      description: Represents an additional attribute for an offer which is not in the predefined fields.
+      properties:
+        key:
+          type: string
+          description: The attribute name. It's not allowed to be empty.
+        value:
+          type: string
+          description: The corresponding attribute value.
+      additionalProperties: false
+      type: object
+      required:
+        - key
+        - value
+    com.patagona.pricemonitor.share.api.ApiOfferV2:
+      description: Represents an offer for a product on a certain domain.
+      properties:
+        deliveryCosts:
+          type: number
+          description: The additional charges for delivering the product to the customer's location.
+        url:
+          type: string
+          description: The direct link to the product page on the domain where this offer can be found.
+        vendorDomainId:
+          type: string
+          description: Optional identifier representing the vendor on a certain domain.
+        price:
+          type: number
+          description: The current listed unit price of the product.
+        availability:
+          type: boolean
+          description: An optional flag indicating whether the product is currently in stock and available for purchase.
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiOfferAttributeV2'
+          description: A list of additional offer details.
+        vendorName:
+          type: string
+          description: The display name of the shop which sells the product.
+        retrievalDate:
+          type: string
+          format: date-time
+          description: Optional timestamp based on ISO 8601 when this offer information was last fetched from the domain.
+        id:
+          type: string
+          description: A unique identifier for the offer. It's crucial that it's unique across all offers independent of the timestamp. If you don't have a unique identifier then please use a UUID.
+        productName:
+          type: string
+          description: The name of the product as listed on the domain.
+        currency:
+          type: string
+          description: The currency in which the price and delivery costs are expressed. Allowed values are ISO 4217 currency codes like "EUR".
+        minDeliveryHours:
+          type: integer
+          description: Optional minimum time, in hours, it takes for the product to be delivered to the customer.
+        maxDeliveryHours:
+          type: integer
+          description: Optional maximum time, in hours, it takes for the product to be delivered to the customer.
+      additionalProperties: false
+      type: object
+      required:
+        - productName
+        - url
+        - attributes
+        - id
+        - vendorName
+        - price
+        - deliveryCosts
+        - currency
+    com.patagona.pricemonitor.share.api.PostProductOfferRequest:
+      description: Represents a single request to post offers for a snapshot. A snapshot is a unique combination of productId, creationDate, and domain.
+      properties:
+        productId:
+          type: string
+          description: Patagona's internal product id.
+        creationDate:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp when the offers have been gathered. This timestamp needs to be more recent compared to already existing offers. Otherwise, the offers will be rejected.
+        domain:
+          type: string
+          description: Origin of the offers.
+        offers:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiOfferV2'
+          description: Non-empty list of offers.
+      additionalProperties: false
+      type: object
+      required:
+        - productId
+        - creationDate
+        - domain
+        - offers
+    QueryPriceRecommendationsV2ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiPriceRecommendation'
+          type: array
+        meta:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PaginationResponse'
+    com.patagona.pricemonitor.share.api.PutResetPasswordRequest:
+      description: Request body for resetting the password
+      properties:
+        token:
+          type: string
+          description: Received via email after requesting a new password.
+        password:
+          type: string
+          description: Password entered by the user.
+      additionalProperties: false
+      type: object
+      required:
+        - token
+        - password
+    com.patagona.pricemonitor.share.api.PostNewPasswordRequest:
+      description: Request body for requesting a new password
+      properties:
+        email:
+          type: string
+          description: Valid email address of an existing pricemonitor account.
+      additionalProperties: false
+      type: object
+      required:
+        - email
+    com.patagona.pricemonitor.share.api.GetContractResponseV3:
+      description: Contract information
+      properties:
+        expirationDate:
+          type: string
+          format: date-time
+          description: The date when contract will expire.
+        description:
+          type: string
+          description: The description for the given contract provided by the end-user.
+        contractType:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ContractType'
+          description: Type of the contract.
+        creationDate:
+          type: string
+          format: date-time
+          description: The creation date of the contract.
+        sid:
+          type: string
+          description: Unique string id of the contract in pricemonitor.
+        companyId:
+          type: number
+          description: The id of the company, in pricemonitor, to which contract belongs to.
+        active:
+          type: boolean
+          description: Indicates if the contract is active or disabled.
+      additionalProperties: false
+      type: object
+      required:
+        - description
+        - active
+        - sid
+        - contractType
+        - creationDate
+        - companyId
+    GetManufacturerV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.GetContractResponseV3'
+    com.patagona.pricemonitor.share.api.Tag:
       properties:
         key:
           type: string
         value:
           type: string
-      required:
-      - key
-      - value
-      type: object
-    com.patagona.pricemonitor.share.api.ApiProductV3:
       additionalProperties: false
+      type: object
+      required:
+        - key
+        - value
+    com.patagona.pricemonitor.share.api.ApiProduct:
       description: A product in the pricemonitor.
-      example:
-        customerProductId: customerProductId
-        gtin: 6.027456183070403
-        referencePrice: 5.962133916683182
-        maxPriceBoundary: 1.4658129805029452
-        name: name
-        id: id
-        minPriceBoundary: 0.8008281904610115
-        tags:
-        - stringValue: stringValue
-          integerValue: 5
-          booleanValue: true
-          doubleValue: 5.962133916683182
-          label: label
-        - stringValue: stringValue
-          integerValue: 5
-          booleanValue: true
-          doubleValue: 5.962133916683182
-          label: label
       properties:
         name:
-          description: Name of the product.
           type: string
+          description: Name of the product.
         tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Tag'
           description: Additional information on this product.
+        minPriceBoundary:
+          type: number
+          description: Maximum price which pricemonitor can recommend for the product. It won't recommend any price above this boundary.
+        gtin:
+          type: number
+          description: GTIN of the product. Can be optionally.
+        customerProductId:
+          type: string
+          description: The customer's id of the product. This field allows to link products in pricemonitor to products in the customer's system.
+        id:
+          type: string
+          description: Id of the product in the pricemonitor.
+        maxPriceBoundary:
+          type: number
+          description: Minimum price which pricemonitor can recommend for the product. It won't recommend any price below this boundary.
+        referencePrice:
+          type: number
+          description: Some price that will be used as benchmark for certain components in pricemonitor.
+      additionalProperties: false
+      type: object
+      required:
+        - tags
+        - id
+        - name
+        - referencePrice
+    QueryProductsByFilterManufacturerV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiProduct'
+          type: array
+    com.patagona.pricemonitor.share.api.Query:
+      description: |-
+        This class specifies a general query language, even though all fields are marked as optional, exactly one has
+        to be specified.
+        Please note that depending on the endpoint only a subset of the query language might be supported.
+        Refer to the endpoint specific documentation to view the restrictions.
+      properties:
+        regex:
+          type: object
+          additionalProperties: false
+          properties:
+            field:
+              type: string
+            pattern:
+              type: string
+          required:
+            - field
+            - pattern
+        in:
+          type: object
+          additionalProperties: false
+          properties:
+            field:
+              type: string
+            query:
+              $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Query'
+          required:
+            - field
+            - query
+        or:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Query'
+        const:
+          type: boolean
+        not:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Query'
+        oneOf:
+          type: object
+          additionalProperties: false
+          properties:
+            field:
+              type: string
+              description: ''
+            values:
+              type: array
+              items:
+                type: string
+              description: ''
+          required:
+            - field
+            - values
+        lt:
+          type: object
+          additionalProperties: false
+          properties:
+            field:
+              type: string
+            value:
+              type: string
+          required:
+            - field
+            - value
+        gt:
+          type: object
+          additionalProperties: false
+          properties:
+            field:
+              type: string
+            value:
+              type: string
+          required:
+            - field
+            - value
+        eq:
+          type: object
+          additionalProperties: false
+          properties:
+            field:
+              type: string
+            value:
+              type: string
+          required:
+            - field
+            - value
+        and:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Query'
+      additionalProperties: false
+      type: object
+      required: []
+    com.patagona.pricemonitor.share.api.ApiQuery:
+      description: This model represents a paginated query. The filter parameter is optional, if it is not set, all values will be returned, paginated by the pagination parameter.
+      properties:
+        pagination:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Pagination'
+          description: ''
+        filter:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Query'
+          description: ''
+      additionalProperties: false
+      type: object
+      required:
+        - pagination
+    com.patagona.pricemonitor.share.api.ApiProductV3:
+      description: A product in the pricemonitor.
+      properties:
+        name:
+          type: string
+          description: Name of the product.
+        tags:
+          type: array
           items:
             $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ExtendedTag'
-          type: array
+          description: Additional information on this product.
         minPriceBoundary:
-          description: Maximum price which pricemonitor can recommend for the product.
-            It won't recommend any price above this boundary.
           type: number
+          description: Maximum price which pricemonitor can recommend for the product. It won't recommend any price above this boundary.
         gtin:
+          type: number
           description: GTIN of the product. Can be optionally.
-          type: number
         customerProductId:
-          description: The customer's id of the product. This field allows to link
-            products in pricemonitor to products in the customer's system.
           type: string
+          description: The customer's id of the product. This field allows to link products in pricemonitor to products in the customer's system.
         id:
+          type: string
           description: Id of the product in the pricemonitor.
-          type: string
         maxPriceBoundary:
-          description: Minimum price which pricemonitor can recommend for the product.
-            It won't recommend any price below this boundary.
           type: number
+          description: Minimum price which pricemonitor can recommend for the product. It won't recommend any price below this boundary.
         referencePrice:
-          description: Some price that will be used as benchmark for certain components
-            in pricemonitor.
           type: number
-      required:
-      - id
-      - name
-      - referencePrice
-      - tags
-      type: object
-    com.patagona.pricemonitor.share.api.ProductMonitoringStatus:
+          description: Some price that will be used as benchmark for certain components in pricemonitor.
       additionalProperties: false
-      description: Describes the monitoring status of a product for all domains of
-        the contract.
-      example:
-        productId: 0.8008281904610115
-        statusOnDomain:
-        - completedAt: 2000-01-23T04:56:07.000+00:00
-          domain: domain
-          startedAt: 2000-01-23T04:56:07.000+00:00
-          outcome:
-            outcome: outcome
-            successful: true
-        - completedAt: 2000-01-23T04:56:07.000+00:00
-          domain: domain
-          startedAt: 2000-01-23T04:56:07.000+00:00
-          outcome:
-            outcome: outcome
-            successful: true
+      type: object
+      required:
+        - tags
+        - id
+        - name
+        - referencePrice
+    QueryProductsManufacturerV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
       properties:
-        productId:
-          description: The product that gets monitored
-          type: number
-        statusOnDomain:
-          description: The monitoring status on each domain. It will contain an entry
-            for each domain which is active for that contract.
+        data:
           items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ProductMonitoringStatusOnDomain'
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiProductV3'
           type: array
-      required:
-      - productId
-      - statusOnDomain
-      type: object
-    com.patagona.pricemonitor.share.api.ProductMonitoringStatusOnDomain:
-      additionalProperties: false
-      description: Describes the monitoring status of a product on a certain domain.
-      example:
-        completedAt: 2000-01-23T04:56:07.000+00:00
-        domain: domain
-        startedAt: 2000-01-23T04:56:07.000+00:00
-        outcome:
-          outcome: outcome
-          successful: true
+    com.patagona.pricemonitor.share.api.DynamicMonitoringSettings:
       properties:
-        domain:
-          description: The domain which gets monitored.
-          type: string
-        startedAt:
-          description: The last time pricemonitor tried to monitor the product on
-            the given domain. If this doesn't exist it mean's that pricemonitor haven't
-            tried to monitor this product on the domain yet. One reason could be that
-            the product is very new or the domain has just recently been added to
-            the contract.
-          format: date-time
-          type: string
-        completedAt:
-          description: The last time pricemonitor completed monitoring the product
-            on the given domain.
-          format: date-time
-          type: string
-        outcome:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ProductMonitoringStatusOnDomainOutcome'
-      required:
-      - domain
-      type: object
-    com.patagona.pricemonitor.share.api.ProductMonitoringStatusOnDomainOutcome:
+        analysisRange:
+          type: integer
+        threshold:
+          type: number
+        adjustedInterval:
+          type: integer
       additionalProperties: false
+      type: object
+      required:
+        - analysisRange
+        - threshold
+        - adjustedInterval
+    com.patagona.pricemonitor.share.api.Callback:
+      properties:
+        method:
+          type: string
+        name:
+          type: string
+        bodyTemplate:
+          type: string
+        url:
+          type: string
+        headers:
+          type: object
+          additionalProperties:
+            type: string
+      additionalProperties: false
+      type: object
+      required:
+        - url
+        - headers
+    com.patagona.pricemonitor.share.api.Callbacks:
+      properties:
+        pricemonitorCompleted:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Callback'
+      additionalProperties: false
+      type: object
+      required:
+        - pricemonitorCompleted
+    com.patagona.pricemonitor.share.api.CustomerContractSettings:
+      description: CustomerContractSettings contains all settings adjustable by the pricemonitor customers.
+      properties:
+        includeDeliveryCosts:
+          type: boolean
+          description: ''
+        domains:
+          type: array
+          items:
+            type: string
+          description: ''
+        dynamicMonitoring:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.DynamicMonitoringSettings'
+          description: ''
+        currency:
+          default: EUR
+          type: string
+          description: The contract's currency as three letter code
+        imageUrlTag:
+          type: string
+          description: The name of the tag that contains the product image url
+        callbacks:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Callbacks'
+          description: ''
+        msrpTag:
+          type: string
+          description: The name of the tag that contains the manufacturers suggested retail price
+        mapTag:
+          type: string
+          description: The name of the tag that contains the minimum advertised price
+      additionalProperties: false
+      type: object
+      required:
+        - domains
+        - includeDeliveryCosts
+    GetCustomerContractSettingsApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CustomerContractSettings'
+    PutCustomerContractSettingsApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CustomerContractSettings'
+    com.patagona.pricemonitor.share.api.ProductMonitoringStatusOnDomainOutcome:
       description: Describes the result of a monitoring attempt.
-      example:
-        outcome: outcome
-        successful: true
       properties:
         successful:
-          description: 'Defines if everything worked as expected. This is the case
-            if: - Offers have been found for the product - The product exists on the
-            domain but is currently not available - The product doesn''t exist on
-            the domain'
           type: boolean
+          description: 'Defines if everything worked as expected. This is the case if: - Offers have been found for the product - The product exists on the domain but is currently not available - The product doesn''t exist on the domain'
         outcome:
-          description: 'Describes the outcome of the monitoring attempt. Can be one
-            of: ProductNotFound, ProductNotAvailable, ProductFound, CaptchaFailure,
-            LayoutFailure, RequestFailure, UnknownFailure, ProductSearchFailure, MissingTaskData,
-            AlreadyCompletedTask, InvalidTaskSession, MissingContractId, UnsupportedDomainFailure'
           type: string
-      required:
-      - outcome
-      - successful
-      type: object
-    com.patagona.pricemonitor.share.api.ProductMonitoringStatusStats:
+          description: 'Describes the outcome of the monitoring attempt. Can be one of: ProductNotFound, ProductNotAvailable, ProductFound, CaptchaFailure, LayoutFailure, RequestFailure, UnknownFailure, ProductSearchFailure, MissingTaskData, AlreadyCompletedTask, InvalidTaskSession, MissingContractId, UnsupportedDomainFailure'
       additionalProperties: false
-      example:
-        outcomes:
-        - count: 1
-          outcome: outcome
-        - count: 1
-          outcome: outcome
-        domain: domain
-        started: 0
-        completed: 6
+      type: object
+      required:
+        - successful
+        - outcome
+    com.patagona.pricemonitor.share.api.ProductMonitoringStatusOnDomain:
+      description: Describes the monitoring status of a product on a certain domain.
+      properties:
+        domain:
+          type: string
+          description: The domain which gets monitored.
+        startedAt:
+          type: string
+          format: date-time
+          description: The last time pricemonitor tried to monitor the product on the given domain. If this doesn't exist it mean's that pricemonitor haven't tried to monitor this product on the domain yet. One reason could be that the product is very new or the domain has just recently been added to the contract.
+        completedAt:
+          type: string
+          format: date-time
+          description: The last time pricemonitor completed monitoring the product on the given domain.
+        outcome:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ProductMonitoringStatusOnDomainOutcome'
+          description: Describes the result of a monitoring attempt.
+      additionalProperties: false
+      type: object
+      required:
+        - domain
+    com.patagona.pricemonitor.share.api.ProductMonitoringStatus:
+      description: Describes the monitoring status of a product for all domains of the contract.
+      properties:
+        productId:
+          type: number
+          description: The product that gets monitored
+        statusOnDomain:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ProductMonitoringStatusOnDomain'
+          description: The monitoring status on each domain. It will contain an entry for each domain which is active for that contract.
+      additionalProperties: false
+      type: object
+      required:
+        - productId
+        - statusOnDomain
+    GetProductMonitoringStatusVendorV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ProductMonitoringStatus'
+          type: array
+    com.patagona.pricemonitor.share.api.ProductMonitoringStatusOutcomeStats:
+      properties:
+        outcome:
+          type: string
+        count:
+          type: integer
+      additionalProperties: false
+      type: object
+      required:
+        - outcome
+        - count
+    com.patagona.pricemonitor.share.api.ProductMonitoringStatusStats:
       properties:
         domain:
           type: string
@@ -14716,836 +9819,457 @@ components:
         completed:
           type: integer
         outcomes:
-          items:
-            $ref: '#/components/schemas/com_patagona_pricemonitor_share_api_ProductMonitoringStatusStats_outcomes'
           type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ProductMonitoringStatusOutcomeStats'
           uniqueItems: true
-      required:
-      - completed
-      - domain
-      - outcomes
-      - started
-      type: object
-    com.patagona.pricemonitor.share.api.EmbedSSOUrlResponseV3:
       additionalProperties: false
-      description: Response body containing signed embed sso url from looker.
-      example:
-        url: url
+      type: object
+      required:
+        - domain
+        - started
+        - completed
+        - outcomes
+    GetProductMonitoringStatusStatsVendorV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ProductMonitoringStatusStats'
+          type: array
+    QueryProductsByFilterVendorV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiProduct'
+          type: array
+    GetPriceRecommendationHistoryApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiPriceRecommendation'
+          type: array
+    QueryProductsVendorV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ApiProductV3'
+          type: array
+    com.patagona.pricemonitor.share.api.PostEmbedSSOUrlRequestV3:
+      description: Request body to retrieve signed embed sso url using looker api.
       properties:
         url:
-          description: The embed sso url.
           type: string
-      required:
-      - url
-      type: object
-    com.patagona.pricemonitor.share.api.ActivateMarketplaceResponseV3:
+          description: The complete URL of the Looker UI page to display in the embed context.
       additionalProperties: false
+      type: object
+      required:
+        - url
+    com.patagona.pricemonitor.share.api.EmbedSSOUrlResponseV3:
+      description: Response body containing signed embed sso url from looker.
+      properties:
+        url:
+          type: string
+          description: The embed sso url.
+      additionalProperties: false
+      type: object
+      required:
+        - url
+    EmbedSSOUrlResponseV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.EmbedSSOUrlResponseV3'
+    com.patagona.pricemonitor.share.api.PostActivateMarketplaceRequestV3:
+      description: Payload for activating marketplace of a seller in our system.
+      properties:
+        marketplaceCountryCode:
+          type: string
+          description: Marketplace country code. You can view complete list here. https://developer-docs.amazon.com/sp-api/docs/marketplace-ids. Currently, only Europe as a region is supported.
+        contractId:
+          type: string
+          description: Pricemonitor contract id
+      additionalProperties: false
+      type: object
+      required:
+        - marketplaceCountryCode
+        - contractId
+    com.patagona.pricemonitor.share.api.ActivateMarketplaceResponseV3:
       description: Activation status of a marketplace of a seller in our system.
-      example:
-        activated: true
       properties:
         activated:
-          description: Whether marketplace is activated or not.
           type: boolean
-      required:
-      - activated
-      type: object
-    com.patagona.pricemonitor.share.api.GetAuthorizationStatusResponseV3:
+          description: Whether marketplace is activated or not.
       additionalProperties: false
+      type: object
+      required:
+        - activated
+    ActivateMarketplaceResponseV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ActivateMarketplaceResponseV3'
+    com.patagona.pricemonitor.share.api.GetAuthorizationStatusResponseV3:
       description: Authorization status of a seller on Amazon.
-      example:
-        authorized: true
       properties:
         authorized:
-          description: Whether a seller is authorized or not.
           type: boolean
-      required:
-      - authorized
-      type: object
-    com.patagona.pricemonitor.share.api.PostAuthorizeSellerResponseV3:
+          description: Whether a seller is authorized or not.
       additionalProperties: false
+      type: object
+      required:
+        - authorized
+    GetAuthorizationStatusResponseV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.GetAuthorizationStatusResponseV3'
+    com.patagona.pricemonitor.share.api.PostAuthorizeSellerRequestV3:
+      description: Seller to be authorized.
+      properties:
+        sellingPartnerId:
+          type: string
+          description: The identifier for the selling partner seller on Amazon.
+        spapiOauthCode:
+          type: string
+          description: The Login with Amazon (LWA) authorization code that you exchange for an LWA refresh token.
+      additionalProperties: false
+      type: object
+      required:
+        - sellingPartnerId
+        - spapiOauthCode
+    com.patagona.pricemonitor.share.api.PostAuthorizeSellerResponseV3:
       description: Successfully authorized seller
-      example:
-        sellerId: 0
       properties:
         sellerId:
-          description: The identifier for the authorized seller.
           type: integer
-      required:
-      - sellerId
+          description: The identifier for the authorized seller.
+      additionalProperties: false
       type: object
+      required:
+        - sellerId
+    PostAuthorizeSellerResponseV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostAuthorizeSellerResponseV3'
     com.patagona.pricemonitor.share.api.MonitoringScheduleV3:
-      additionalProperties: false
-      description: MonitoringScheduleV3 represents monitoring schedule that can be
-        adjustable by the price-monitor customers.
-      example:
-        schedulerJobId: schedulerJobId
-        schedule: schedule
-        domainQuery:
-          regex:
-            field: field
-            pattern: pattern
-          oneOf:
-            field: field
-            values:
-            - values
-            - values
-          or:
-          - null
-          - null
-          const: true
-          in:
-            field: field
-          and:
-          - null
-          - null
-          lt:
-            field: field
-            value: value
-          eq:
-            field: field
-            value: value
-          gt:
-            field: field
-            value: value
-        quota: 0.8008281904610115
-        unfulfilledOnly: true
-        id: 6.027456183070403
-        productQuery:
-          regex:
-            field: field
-            pattern: pattern
-          oneOf:
-            field: field
-            values:
-            - values
-            - values
-          or:
-          - null
-          - null
-          const: true
-          in:
-            field: field
-          and:
-          - null
-          - null
-          lt:
-            field: field
-            value: value
-          eq:
-            field: field
-            value: value
-          gt:
-            field: field
-            value: value
+      description: MonitoringScheduleV3 represents monitoring schedule that can be adjustable by the price-monitor customers.
       properties:
         productQuery:
           $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Query'
+          description: Allows restrict monitoring to certain products.
         quota:
-          description: 'Defines how many products should get monitored. Default to
-            1.0 which means that all products are monitored. Allowed values: 0.0 <
-            quota <= 1.0'
           type: number
+          description: 'Defines how many products should get monitored. Default to 1.0 which means that all products are monitored. Allowed values: 0.0 < quota <= 1.0'
         domainQuery:
           $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Query'
+          description: Allows restrict monitoring to certain domains.
         unfulfilledOnly:
-          description: When it's set to true, then the monitoring considers only products
-            on domains where no offers are found within 24h. Default false.
           type: boolean
+          description: When it's set to true, then the monitoring considers only products on domains where no offers are found within 24h. Default false.
         id:
-          description: Id that uniquely identifies a monitoring schedule.
           type: number
+          description: Id that uniquely identifies a monitoring schedule.
         schedule:
+          type: string
           description: Only valid CRON expressions are allowed. See Cron spec [[https://www.alonsodomin.me/cron4s/userguide/index.html]].
-          type: string
         schedulerJobId:
-          description: Internal job id used by the scheduler.
           type: string
-      required:
-      - id
-      - quota
-      - schedule
-      - schedulerJobId
-      - unfulfilledOnly
-      type: object
-    com.patagona.pricemonitor.share.api.VendorShopMappingV3:
+          description: Internal job id used by the scheduler.
       additionalProperties: false
-      description: Online shops can have different names per domain despite they belong
-        to the same entity. This entity is further called "vendor". A vendor shop
-        mapping represents shops which are associated to a vendor.
-      example:
-        shops:
-        - domain: domain
-          name: name
-        - domain: domain
-          name: name
-        id: 0.8008281904610115
-        vendorName: vendorName
+      type: object
+      required:
+        - schedule
+        - quota
+        - schedulerJobId
+        - id
+        - unfulfilledOnly
+    GetMonitoringSchedulesApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.MonitoringScheduleV3'
+          type: array
+    com.patagona.pricemonitor.share.api.PostMonitoringScheduleRequestV3:
+      description: A request body containing monitoring schedule.
+      properties:
+        productQuery:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Query'
+          description: Allows restrict monitoring to certain products.
+        quota:
+          type: number
+          description: 'Defines how many products should get monitored. Default to 1.0 which means that all products are monitored. Allowed values: 0.0 < quota <= 1.0'
+        domainQuery:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Query'
+          description: Allows restrict monitoring to certain domains.
+        unfulfilledOnly:
+          type: boolean
+          description: When it's set to true, then the monitoring considers only products on domains where no offers are found within 24h. Default false.
+        schedule:
+          type: string
+          description: Only valid CRON expressions are allowed. See Cron spec [[https://www.alonsodomin.me/cron4s/userguide/index.html]]
+      additionalProperties: false
+      type: object
+      required:
+        - schedule
+        - quota
+        - unfulfilledOnly
+    PutMonitoringSchedulesApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.MonitoringScheduleV3'
+    com.patagona.pricemonitor.share.api.DeleteByNumericIdApiResponse:
+      description: Successful delete response.
+      properties:
+        data:
+          type: number
+          description: numeric id that has been deleted
+      additionalProperties: false
+      type: object
+      required:
+        - data
+    com.patagona.pricemonitor.share.api.VendorShopMappingV3:
+      description: Online shops can have different names per domain despite they belong to the same entity. This entity is further called "vendor". A vendor shop mapping represents shops which are associated to a vendor.
       properties:
         id:
-          description: Unique identifier of a vendor
           type: number
+          description: Unique identifier of a vendor
         vendorName:
-          description: Vendor name
           type: string
+          description: Vendor name
         shops:
-          description: List of shops associated with the specified vendor
+          type: array
           items:
             $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ShopV3'
-          type: array
           uniqueItems: true
-      required:
-      - id
-      - shops
-      - vendorName
-      type: object
-    com.patagona.pricemonitor.share.api.PostAccountResponseV3:
+          description: List of shops associated with the specified vendor
       additionalProperties: false
-      description: A response body that contains information for a newly created account.
-      example:
-        name: name
-        id: 0.8008281904610115
-        email: email
+      type: object
+      required:
+        - id
+        - vendorName
+        - shops
+    GetVendorShopMappingsApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
       properties:
-        id:
-          description: Defines the Pricemonitor user id of newly create user account.
-          type: number
-        name:
-          description: Defines name of newly create user account.
+        data:
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.VendorShopMappingV3'
+          type: array
+    com.patagona.pricemonitor.share.api.PostVendorShopMappingRequestV3:
+      description: Request body for creating a vendor and their associated shops.
+      properties:
+        vendorName:
           type: string
+          description: Vendor name
+        shops:
+          type: array
+          items:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.ShopV3'
+          uniqueItems: true
+          description: List of associated shops
+      additionalProperties: false
+      type: object
+      required:
+        - vendorName
+        - shops
+    VendorShopMappingV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
+      properties:
+        data:
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.VendorShopMappingV3'
+    com.patagona.pricemonitor.share.api.PostAccountRequestV3:
+      description: A request body that contains information for creation of a new account.
+      properties:
+        name:
+          type: string
+          description: Defines the name of the new user account.
         email:
-          description: Defines the email of newly created user account.
           type: string
-      required:
-      - email
-      - id
-      - name
-      type: object
-    com.patagona.pricemonitor.share.api.AmazonBuyboxProductStatsV3:
+          description: Defines the email of the new user account.
+        password:
+          type: string
+          description: Defines the password for the new user account.
       additionalProperties: false
-      description: Shows if product belongs to Amazon Buybox
-      example:
-        productId: 0.8008281904610115
-        isInPrimeBuybox: true
-        isInNonPrimeBuybox: true
-      properties:
-        productId:
-          description: Internal product identifier
-          type: number
-        isInPrimeBuybox:
-          description: Indicates if product is Amazon Prime product and is in Amazon
-            Buybox
-          type: boolean
-        isInNonPrimeBuybox:
-          description: Indicates if product is in Amazon Buybox
-          type: boolean
-      required:
-      - isInNonPrimeBuybox
-      - isInPrimeBuybox
-      - productId
       type: object
-    Callbacks_pricemonitorCompleted:
-      example:
-        headers:
-          key: headers
-        bodyTemplate: bodyTemplate
-        method: method
-        name: name
-        url: url
-      properties:
-        bodyTemplate:
-          type: string
-        headers:
-          additionalProperties:
-            type: string
-          type: object
-        method:
-          type: string
-        name:
-          type: string
-        url:
-          type: string
-    ConstantOfferFilter_constant:
-      example:
-        value: true
-      properties:
-        value:
-          type: boolean
-    AndOfferFilter_and:
-      example:
-        filters:
-        - constant:
-            value: true
-        - constant:
-            value: true
-      properties:
-        filters:
-          items:
-            $ref: '#/components/schemas/ConstantOfferFilter'
-          type: array
-    PutPluginRegistrationRequest_allOf:
-      properties:
-        version:
-          enum:
-          - "1"
-          type: string
-    Feed_fields:
-      example:
-        default: default
-        name: name
-        label: label
-      properties:
-        default:
-          type: string
-        label:
-          type: string
-        name:
-          type: string
-    GetOffersResponse_attributes:
-      example:
-        value: value
-        key: key
-      properties:
-        key:
-          type: string
-        value:
-          type: string
-    GetOffersResponse_offers:
-      description: An offer by a specific vendor for a certain product
-      example:
-        availability: '{}'
-        creationDate: 2000-01-23T04:56:07.000+00:00
-        productName: productName
-        url: url
-        vendorIdOnDomain: vendorIdOnDomain
-        approved: true
-        minDeliveryTime: '{}'
-        deliveryCosts: 6.027456183070403
-        maxDeliveryTime: '{}'
-        price: 1.4658129805029452
-        vendor: vendor
-        domain: domain
-        attributes:
-        - value: value
-          key: key
-        - value: value
-          key: key
-      properties:
-        approved:
-          type: boolean
-        attributes:
-          items:
-            $ref: '#/components/schemas/GetOffersResponse_attributes'
-          type: array
-        availability:
-          type: object
-        creationDate:
-          format: date-time
-          type: string
-        deliveryCosts:
-          format: double
-          type: number
-        domain:
-          type: string
-        maxDeliveryTime:
-          type: object
-        minDeliveryTime:
-          type: object
-        price:
-          format: double
-          type: number
-        productName:
-          type: string
-        url:
-          type: string
-        vendor:
-          type: string
-        vendorIdOnDomain:
-          type: string
-    GetOffersResponse_data:
-      description: The GTIN of a product and all of its offers
-      example:
-        offers:
-        - availability: '{}'
-          creationDate: 2000-01-23T04:56:07.000+00:00
-          productName: productName
-          url: url
-          vendorIdOnDomain: vendorIdOnDomain
-          approved: true
-          minDeliveryTime: '{}'
-          deliveryCosts: 6.027456183070403
-          maxDeliveryTime: '{}'
-          price: 1.4658129805029452
-          vendor: vendor
-          domain: domain
-          attributes:
-          - value: value
-            key: key
-          - value: value
-            key: key
-        - availability: '{}'
-          creationDate: 2000-01-23T04:56:07.000+00:00
-          productName: productName
-          url: url
-          vendorIdOnDomain: vendorIdOnDomain
-          approved: true
-          minDeliveryTime: '{}'
-          deliveryCosts: 6.027456183070403
-          maxDeliveryTime: '{}'
-          price: 1.4658129805029452
-          vendor: vendor
-          domain: domain
-          attributes:
-          - value: value
-            key: key
-          - value: value
-            key: key
-        gtin: 0
-        productId: productId
-        tags:
-        - value: value
-          key: key
-        - value: value
-          key: key
-      properties:
-        tags:
-          items:
-            $ref: '#/components/schemas/Tag'
-          type: array
-        gtin:
-          format: int64
-          type: integer
-        offers:
-          items:
-            $ref: '#/components/schemas/GetOffersResponse_offers'
-          type: array
-        productId:
-          description: Unique product identifier within pricemonitor
-          type: string
-    GetPriceRecommendationsResponse_priceRecommendations:
-      example:
-        identifier: identifier
-        gtin: 6
-        recommendedPrice: 1.4658129805029452
-        currentPrice: 0.8008281904610115
-        currency: currency
-      properties:
-        currency:
-          type: string
-        currentPrice:
-          format: double
-          type: number
-        gtin:
-          format: int64
-          type: integer
-        identifier:
-          type: string
-        recommendedPrice:
-          format: double
-          type: number
-    ScenarioStrategyResponse_data:
-      example:
-        updateDate: 2000-01-23T04:56:07.000+00:00
-        schemaVersion: 6
-        updatedBy: updatedBy
-        createdBy: createdBy
-        description: description
-        id: 0
-        title: title
-        strategy: '{}'
-        creationDate: 2000-01-23T04:56:07.000+00:00
+      required:
+        - name
+        - email
+        - password
+    com.patagona.pricemonitor.share.api.PostAccountResponseV3:
+      description: A response body that contains information for a newly created account.
       properties:
         id:
-          description: Id of the scenario strategy.
-          type: integer
-        title:
-          description: Title of the scenario strategy. Should not be empty and a maximum
-            of 50 chars is allowed
+          type: number
+          description: Defines the Pricemonitor user id of newly create user account.
+        name:
           type: string
-        description:
-          description: Description of the scenario strategy. Maximum of 1000 chars
-            allowed
+          description: Defines name of newly create user account.
+        email:
           type: string
-        schemaVersion:
-          description: Version of the schema the scenario strategy is encoded in
-          type: integer
-        strategy:
-          description: This is a placeholder for a pricing strategy. These are using
-            advanced features and are not covered by openapi. If you need to work
-            with pricing strategies please contract us.
-          type: object
-        creationDate:
-          description: Timestamp of creating the strategy scenario
-          format: date-time
-          type: string
-        createdBy:
-          description: Email address of the user who created the strategy scenario
-          type: string
-        updateDate:
-          description: Timestamp of the last update operation
-          format: date-time
-          type: string
-        updatedBy:
-          description: Email address of the user who last updated the strategy scenario
-          type: string
-    PostOffersResponse_data:
+          description: Defines the email of newly created user account.
+      additionalProperties: false
+      type: object
+      required:
+        - id
+        - name
+        - email
+    PostAccountResponseV3ApiResponse:
+      required:
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
       properties:
         data:
-          example: true
-          type: boolean
-        errors:
-          items:
-            $ref: '#/components/schemas/ApiError'
-          type: array
-    DeleteProductsApiResponse_data:
-      example:
-        deleted: 0
-      properties:
-        deleted:
-          description: Number of deleted products
-          type: integer
-    PostProductsApiResponse_data:
-      example:
-        productId: productId
+          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostAccountResponseV3'
+    com.patagona.pricemonitor.share.api.AmazonBuyboxProductStatsV3:
+      description: Shows if product belongs to Amazon Buybox
       properties:
         productId:
-          description: The pricemonitor product id of the added product
-          type: string
-    TaskWithContractResourceApiResponse_failures:
-      example:
-        messageId: messageId
-        attributes:
-          key: '{}'
-      properties:
-        attributes:
-          additionalProperties:
-            type: object
-          type: object
-        messageId:
-          type: string
-    GenericTaskWithUrl_allOf:
-      description: A basic task type containing the URL. Additional fields can be
-        contained depending on specific task type.
-      properties:
-        url:
-          description: The URL of the task
-          type: string
+          type: number
+          description: Internal product identifier
+        isInPrimeBuybox:
+          type: boolean
+          description: Indicates if product is Amazon Prime product and is in Amazon Buybox
+        isInNonPrimeBuybox:
+          type: boolean
+          description: Indicates if product is in Amazon Buybox
+      additionalProperties: false
+      type: object
       required:
-      - url
-    UpdateTaskRequestV2_allOf:
-      properties:
-        contractId:
-          description: The contract SID to update the task for
-          type: string
+        - productId
+        - isInPrimeBuybox
+        - isInNonPrimeBuybox
+    AmazonBuyboxProductStatsV3ApiResponse:
       required:
-      - contractId
-    com_patagona_pricemonitor_share_api_CustomerOrderV2_productMappings:
-      example:
-        source: source
-        target: target
-      properties:
-        source:
-          description: Identifier field within item. Only valid value is 'itemId'
-          type: string
-        target:
-          description: Must be 'customerProductId' or 'productId' since plugins are
-            still publishing both values. The semantics are actually the same. In
-            both cases they address the customerProductId.
-          type: string
-      required:
-      - source
-      - target
-    PostOrdersBulkApiResponse_data:
-      example:
-        orders:
-        - referrer: referrer
-          productMappings:
-          - source: source
-            target: target
-          - source: source
-            target: target
-          orderId: orderId
-          totalPrice: 5.637376656633329
-          origin: origin
-          currency: currency
-          creationDate: 2000-01-23T04:56:07.000+00:00
-          items:
-          - unitPrice: 6.027456183070403
-            itemId: itemId
-            quantity: 1
-            taxPercentage: 5.962133916683182
-          - unitPrice: 6.027456183070403
-            itemId: itemId
-            quantity: 1
-            taxPercentage: 5.962133916683182
-          shippingCosts: 0.8008281904610115
-        - referrer: referrer
-          productMappings:
-          - source: source
-            target: target
-          - source: source
-            target: target
-          orderId: orderId
-          totalPrice: 5.637376656633329
-          origin: origin
-          currency: currency
-          creationDate: 2000-01-23T04:56:07.000+00:00
-          items:
-          - unitPrice: 6.027456183070403
-            itemId: itemId
-            quantity: 1
-            taxPercentage: 5.962133916683182
-          - unitPrice: 6.027456183070403
-            itemId: itemId
-            quantity: 1
-            taxPercentage: 5.962133916683182
-          shippingCosts: 0.8008281904610115
-        version: version
-      properties:
-        orders:
-          items:
-            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.CustomerOrderV2'
-          type: array
-        version:
-          type: string
-    PostOrdersBulkApiResponse_data_1:
-      example:
-        data:
-          orders:
-          - referrer: referrer
-            productMappings:
-            - source: source
-              target: target
-            - source: source
-              target: target
-            orderId: orderId
-            totalPrice: 5.637376656633329
-            origin: origin
-            currency: currency
-            creationDate: 2000-01-23T04:56:07.000+00:00
-            items:
-            - unitPrice: 6.027456183070403
-              itemId: itemId
-              quantity: 1
-              taxPercentage: 5.962133916683182
-            - unitPrice: 6.027456183070403
-              itemId: itemId
-              quantity: 1
-              taxPercentage: 5.962133916683182
-            shippingCosts: 0.8008281904610115
-          - referrer: referrer
-            productMappings:
-            - source: source
-              target: target
-            - source: source
-              target: target
-            orderId: orderId
-            totalPrice: 5.637376656633329
-            origin: origin
-            currency: currency
-            creationDate: 2000-01-23T04:56:07.000+00:00
-            items:
-            - unitPrice: 6.027456183070403
-              itemId: itemId
-              quantity: 1
-              taxPercentage: 5.962133916683182
-            - unitPrice: 6.027456183070403
-              itemId: itemId
-              quantity: 1
-              taxPercentage: 5.962133916683182
-            shippingCosts: 0.8008281904610115
-          version: version
-        errors:
-        - code: code
-          message: message
-        - code: code
-          message: message
+        - data
+      type: object
+      additionalProperties: false
+      description: ''
       properties:
         data:
-          $ref: '#/components/schemas/PostOrdersBulkApiResponse_data'
-        errors:
           items:
-            $ref: '#/components/schemas/ApiError'
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.AmazonBuyboxProductStatsV3'
           type: array
-    com_patagona_pricemonitor_share_api_DeleteOrdersByQueryRequestV3_orders:
-      properties:
-        orderId:
-          description: Unique identifier of the order
-          type: string
-        creationDate:
-          description: Creation date of the corresponding order. It is a Timestamp
-            in UTC time zone
-          format: date-time
-          type: string
-      required:
-      - creationDate
-      - orderId
-    com_patagona_pricemonitor_share_api_PricesByDayByProductIdResponseV2_prices:
-      example:
-        deliveryCosts: 6.027456183070403
-        price: 0.8008281904610115
-        timestamp: 2000-01-23T04:56:07.000+00:00
-      properties:
-        price:
-          description: The price
-          type: number
-        deliveryCosts:
-          description: The delivery costs
-          type: number
-        timestamp:
-          description: The timestamp of when the price was found
-          format: date-time
-          type: string
-      required:
-      - deliveryCosts
-      - price
-      - timestamp
-    com_patagona_pricemonitor_share_api_ApiOfferV2_attributes:
-      example:
-        value: value
-        key: key
-      properties:
-        key:
-          description: The attribute name. It's not allowed to be empty.
-          type: string
-        value:
-          description: The corresponding attribute value.
-          type: string
-      required:
-      - key
-      - value
-    com_patagona_pricemonitor_share_api_Query_regex:
-      example:
-        field: field
-        pattern: pattern
-      properties:
-        field:
-          type: string
-        pattern:
-          type: string
-      required:
-      - field
-      - pattern
-    com_patagona_pricemonitor_share_api_Query_in:
-      example:
-        field: field
-      properties:
-        field:
-          type: string
-        query:
-          $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.Query'
-      required:
-      - field
-      - query
-    com_patagona_pricemonitor_share_api_Query_oneOf:
-      example:
-        field: field
-        values:
-        - values
-        - values
-      properties:
-        field:
-          type: string
-        values:
-          items:
-            type: string
-          type: array
-      required:
-      - field
-      - values
-    com_patagona_pricemonitor_share_api_Query_lt:
-      example:
-        field: field
-        value: value
-      properties:
-        field:
-          type: string
-        value:
-          type: string
-      required:
-      - field
-      - value
-    com_patagona_pricemonitor_share_api_Callbacks_pricemonitorCompleted:
-      example:
-        headers:
-          key: headers
-        method: method
-        bodyTemplate: bodyTemplate
-        name: name
-        url: url
-      properties:
-        method:
-          type: string
-        name:
-          type: string
-        bodyTemplate:
-          type: string
-        url:
-          type: string
-        headers:
-          additionalProperties:
-            type: string
-          type: object
-      required:
-      - headers
-      - url
-    com_patagona_pricemonitor_share_api_GetAllDomainsV3_domains:
-      example:
-        domain: domain
-        name: name
-        domainId: 0.8008281904610115
-        offerSources:
-        - offerSources
-        - offerSources
-      properties:
-        domain:
-          description: domain url
-          type: string
-        domainId:
-          description: internal domain id
-          type: number
-        offerSources:
-          description: 'list of offerSources for the domain OfferSource:  Describes
-            the origin of the offers. Domain may have more than one offer sources.
-            Here are the possible offer sources: DEFAULT_MONITORING Offers - which
-            are gathered via the monitoring-pipeline by a standard product search.
-            This is typically done via GTIN. CUSTOM_MONITORING Offers - which are
-            gathered via the monitoring-pipeline by a customized search. For instance
-            via tags. OMNIA_CUSTOM_SPIDERING Offers - which originate from omnia custom
-            spidering sources. The domain needs to be prefixed with "omnia.custom.spidering.".
-            PUSH_API Offers - which originate from services where we have a direct
-            API connection and get informed about offer changes. Example: Offers from
-            Amazon-Repricer OTHER Offers - which originate from other sources e.g.
-            Scripts which publish offers'
-          items:
-            type: string
-          type: array
-          uniqueItems: true
-        name:
-          description: display name for the domain
-          type: string
-      required:
-      - domain
-      - domainId
-      - name
-      - offerSources
-    com_patagona_pricemonitor_share_api_ProductMonitoringStatusStats_outcomes:
-      example:
-        count: 1
-        outcome: outcome
-      properties:
-        outcome:
-          type: string
-        count:
-          type: integer
-      required:
-      - count
-      - outcome
   securitySchemes:
     BasicAuth:
       scheme: basic
       type: http
     BearerAuth:
-      bearerFormat: JWT
-      scheme: bearer
       type: http
+      scheme: bearer
+      bearerFormat: JWT
+  requestBodies:
+    PostOfferStatisticsRequestV31Enriched:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/com.patagona.pricemonitor.share.api.PostOfferStatisticsRequestV31'
+          example:
+            pagination:
+              start: 0
+              limit: 10
+            range:
+              start: '2023-10-17T08:00:00Z'
+              end: '2023-10-19T08:00:00Z'
+            filter:
+              oneOf:
+                field: customerProductId
+                values:
+                  - '1'
+                  - '2'
+                  - '3'
+                  - '4'
+                  - '5'
+                  - '6'
+                  - '7'
+                  - '8'
+                  - '9'
+                  - '10'
+      description: |
+        The request body may include an optional products query. If omitted, all products are queried. Currently, product queries can be performed on two attributes:
+          - "customerProductId"
+          - "productId" (Patagona's internal product id; must be a numerical integer)
+
+        Pagination is supported with a maximum limit of 10,000. For optimized performance:
+          - Use a limit of 10,000 products per page when querying all products of a contract.
+          - Prefer using "productId" for queries when a product query is utilized.
+
+        Pagination operates based on the provided products query.
+        This is particularly useful when querying a set of customerProductId's.
+        For chunked requests over a set of ids, it's straightforward to specify up to 10,000 customerProductId's in the query with pagination set at start: 0, limit: 10,000.
+
+        The allowed query pattern is structured as follows:
+
+        { <br>
+        &nbsp;&nbsp;"pagination": { <br>
+        &nbsp;&nbsp;&nbsp;&nbsp;"start": ${start}, <br>
+        &nbsp;&nbsp;&nbsp;&nbsp;"limit": ${limit} <br>
+        &nbsp;&nbsp;}, <br>
+        &nbsp;&nbsp;"range": { <br>
+        &nbsp;&nbsp;&nbsp;&nbsp;"start": ${start}, <br>
+        &nbsp;&nbsp;&nbsp;&nbsp;"end": ${end} <br>
+        &nbsp;&nbsp;}, <br>
+        &nbsp;&nbsp;"filter": { <br>
+        &nbsp;&nbsp;&nbsp;&nbsp;"oneOf": { <br>
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"field": "customerProductId", <br>
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"values": [${customerProductIds as a list of strings}] <br>
+        &nbsp;&nbsp;&nbsp;&nbsp;} <br>
+        &nbsp;&nbsp;} <br>
+        } <br>
+        <br>


### PR DESCRIPTION
Downgrades an OAS 3.1 document to still allow proxy generation using old `openapitools/openapi-generator-cli` versions.

- Fixed an incorrect variable name indicating v4.3.1.
- Skip validation checks on the API YAML by the old generator versions. We'll validate/lint the YAML elsewhere.
- Change the API YAML to example OAS 3.1 document to test with. It will be overwritten later by an automatic push from a `patagona-api` release.
- Generate Scala before Python proxies to detect more important failures faster.
