### PR TITLE
CON-697 fix failing CICD pipeline

### DIFF
--- a/.github/workflows/scala-shttp-cd.yaml
+++ b/.github/workflows/scala-shttp-cd.yaml
@@ -26,7 +26,10 @@ jobs:
     env:
       AWS_DEFAULT_REGION: eu-west-1
       _JAVA_OPTIONS: "-Dsbt.log.noformat=true"
-      SBT_VERSION: "1.9.9"
+      # Please keep this version in sync with
+      # - clients/pricemonitor-internal-scala-sttp/project/build.properties
+      # - clients-test/pricemonitor-internal-scala-sttp-test/project/build.properties
+      SBT_VERSION: "1.8.2"
     steps:
     # https://www.automat-it.com/post/using-github-actions-with-aws-iam-roles
     # https://github.com/aws-actions/configure-aws-credentials/blob/master/action.yml

--- a/.github/workflows/scala-shttp-cd.yaml
+++ b/.github/workflows/scala-shttp-cd.yaml
@@ -4,6 +4,7 @@ on:
   release:
     types: [created]
 
+
 defaults:
   run:
     working-directory: clients/pricemonitor-internal-scala-sttp/
@@ -24,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       AWS_DEFAULT_REGION: eu-west-1
+      _JAVA_OPTIONS: "-Dsbt.log.noformat=true"
+      SBT_VERSION: "1.9.9"
     steps:
     # https://www.automat-it.com/post/using-github-actions-with-aws-iam-roles
     # https://github.com/aws-actions/configure-aws-credentials/blob/master/action.yml
@@ -37,10 +40,10 @@ jobs:
         aws-region: ${{env.AWS_DEFAULT_REGION}}
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Setup Scala
-      uses: olafurpg/setup-scala@v11
+    - name: Setup Java and SBT
+      uses: coursier/setup-action@v1
       with:
-        java-version: "adopt@1.8"
+        apps: sbt:${{ env.SBT_VERSION }}
     - name: Coursier cache
       uses: coursier/cache-action@v6
     - name: Build

--- a/.github/workflows/scala-sttp-build.yaml
+++ b/.github/workflows/scala-sttp-build.yaml
@@ -10,13 +10,16 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      _JAVA_OPTIONS: "-Dsbt.log.noformat=true"
+      SBT_VERSION: "1.9.9"
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Setup Scala
-      uses: olafurpg/setup-scala@v11
+    - name: Setup Java and SBT
+      uses: coursier/setup-action@v1
       with:
-        java-version: "adopt@1.8"
+        apps: sbt:${{ env.SBT_VERSION }}
     - name: Coursier cache
       uses: coursier/cache-action@v6
     - name: Build

--- a/.github/workflows/scala-sttp-build.yaml
+++ b/.github/workflows/scala-sttp-build.yaml
@@ -12,7 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       _JAVA_OPTIONS: "-Dsbt.log.noformat=true"
-      SBT_VERSION: "1.9.9"
+      # Please keep this version in sync with
+      # - clients/pricemonitor-internal-scala-sttp/project/build.properties
+      # - clients-test/pricemonitor-internal-scala-sttp-test/project/build.properties
+      SBT_VERSION: "1.8.2"
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/clients/pricemonitor-internal-scala-sttp/project/build.properties
+++ b/clients/pricemonitor-internal-scala-sttp/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.8.2


### PR DESCRIPTION
The last working CICD pipeline [1] has SBT version 1.9.9, so I used the same by replacing different action.

[1] https://github.com/Patagona/pricemonitor-clients/actions/runs/8970799470/job/24635110756