### PR TITLE
get openapi yaml from new path and let curl fail if the status code i…

### DIFF
--- a/get-openapi.sh
+++ b/get-openapi.sh
@@ -5,7 +5,7 @@ sleep 60
 
 # Download the combined OpenAPI specification file.
 branch_name=release-general-${API_VERSION}
-url=https://api.github.com/repos/Patagona/patagona-api-docs/contents/assets-joined/internal-with-scheduler-openapi.yaml?ref=${branch_name}
+url=https://api.github.com/repos/Patagona/patagona-api-docs/contents/internal-api/omnia-internal.yaml?ref=${branch_name}
 echo "Downloading file $url"
 
-curl -v -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.raw" $url -o openapi-internal.yaml
+curl -v --fail-with-body -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.raw" $url -o openapi-internal.yaml


### PR DESCRIPTION
…s >= 400 to find future issues faster